### PR TITLE
fix: accept linux ping socket echo replies

### DIFF
--- a/src/protocol/ping.zig
+++ b/src/protocol/ping.zig
@@ -140,7 +140,7 @@ fn icmpPingAddress(addr: net.Address) !i64 {
         if (ready == 0) return error.Timeout;
         var buf: [1500]u8 = undefined;
         const n = try compat.recvFrom(sock, &buf);
-        if (isEchoReply(buf[0..n], ident, seq)) return compat.milliTimestamp() - start;
+        if (isEchoReply(buf[0..n], seq)) return compat.milliTimestamp() - start;
     }
     return error.Timeout;
 }
@@ -172,33 +172,35 @@ fn icmp6PingAddress(addr: net.Address) !i64 {
         if (ready == 0) return error.Timeout;
         var buf: [1500]u8 = undefined;
         const n = try compat.recvFrom(sock, &buf);
-        if (isEchoReply6(buf[0..n], ident, seq)) return compat.milliTimestamp() - start;
+        if (isEchoReply6(buf[0..n], seq)) return compat.milliTimestamp() - start;
     }
     return error.Timeout;
 }
 
-fn isEchoReply(bytes: []const u8, ident: u16, seq: u16) bool {
+fn isEchoReply(bytes: []const u8, seq: u16) bool {
     var off: usize = 0;
     if (bytes.len >= 20 and (bytes[0] >> 4) == 4) off = (bytes[0] & 0x0f) * 4;
     if (bytes.len < off + 8) return false;
     if (bytes[off] != 0 or bytes[off + 1] != 0) return false;
-    const got_ident = (@as(u16, bytes[off + 4]) << 8) | bytes[off + 5];
     const got_seq = (@as(u16, bytes[off + 6]) << 8) | bytes[off + 7];
-    return (got_ident == ident or got_ident == 0) and got_seq == seq;
+    return got_seq == seq;
 }
 
-fn isEchoReply6(bytes: []const u8, ident: u16, seq: u16) bool {
+fn isEchoReply6(bytes: []const u8, seq: u16) bool {
     var off: usize = 0;
     if (bytes.len >= 40 and (bytes[0] >> 4) == 6) off = 40;
     if (bytes.len < off + 8) return false;
     if (bytes[off] != 129 or bytes[off + 1] != 0) return false;
-    const got_ident = (@as(u16, bytes[off + 4]) << 8) | bytes[off + 5];
     const got_seq = (@as(u16, bytes[off + 6]) << 8) | bytes[off + 7];
-    return (got_ident == ident or got_ident == 0) and got_seq == seq;
+    return got_seq == seq;
 }
 
-pub fn isIcmp6EchoReplyForTest(bytes: []const u8, ident: u16, seq: u16) bool {
-    return isEchoReply6(bytes, ident, seq);
+pub fn isIcmpEchoReplyForTest(bytes: []const u8, _: u16, seq: u16) bool {
+    return isEchoReply(bytes, seq);
+}
+
+pub fn isIcmp6EchoReplyForTest(bytes: []const u8, _: u16, seq: u16) bool {
+    return isEchoReply6(bytes, seq);
 }
 
 pub fn parseTcpTarget(target: []const u8) !TcpTarget {

--- a/test/ping_test.zig
+++ b/test/ping_test.zig
@@ -41,6 +41,18 @@ test "icmp checksum is deterministic" {
     try std.testing.expectEqual(@as(u16, 0), ping.icmpChecksum(&packet));
 }
 
+test "icmp echo reply parser accepts linux datagram socket rewritten identifier" {
+    var packet = [_]u8{0} ** 28;
+    packet[0] = 0x45; // IPv4 header, 20 bytes.
+    packet[20] = 0; // echo reply
+    packet[21] = 0;
+    packet[24] = 0x56; // Linux ping sockets may rewrite ICMP id.
+    packet[25] = 0x78;
+    packet[26] = 0;
+    packet[27] = 1;
+    try std.testing.expect(ping.isIcmpEchoReplyForTest(&packet, 0x1234, 1));
+}
+
 test "icmp6 echo reply parser accepts ipv6 payload" {
     var packet = [_]u8{0} ** 48;
     packet[0] = 0x60;


### PR DESCRIPTION
## Summary
- Accept ICMP echo replies from Linux ping sockets when the kernel rewrites the ICMP identifier.
- Keep matching on echo-reply type and sequence number.
- Add a regression test for rewritten IPv4 identifiers.

## Root cause
On the live Debian host, system `ping` works, but `komari-agent v0.1.19 ping-test icmp 1.1.1.1` returns `-1`. A patched release-target build returns normal latency values. Linux datagram ping sockets can rewrite the ICMP identifier, so requiring the reply identifier to match the packet identifier causes valid replies to be discarded.

## Verification
- `/root/.local/zig/zig-x86_64-linux-0.16.0/zig build test`
- `/root/.local/zig/zig-x86_64-linux-0.16.0/zig build -Doptimize=ReleaseSmall -Dversion=dev -Dtarget=x86_64-linux-musl`
- `/root/.local/zig/zig-x86_64-linux-0.16.0/zig build -Doptimize=ReleaseSmall -Dversion=dev`
- `python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --terminal --no-exec`
- Live host temporary binary check:
  - current v0.1.19: `icmp 1.1.1.1 => -1`
  - patched x86_64-linux-musl: `icmp 1.1.1.1 => 2`, `icmp 8.8.8.8 => 1`, `icmp nz2.011f.com => 159`
