### PR TITLE
fix: fail fast to github mirrors on slow downloads

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,10 @@ github_proxy=""
 github_proxy_list="${KOMARI_GITHUB_PROXIES:-https://gh.llkk.cc https://gh-proxy.com https://ghproxy.net https://ghfast.top https://ghproxy.cc}"
 install_version=""
 komari_args=""
+download_connect_timeout="${KOMARI_DOWNLOAD_CONNECT_TIMEOUT:-8}"
+download_max_time="${KOMARI_DOWNLOAD_MAX_TIME:-20}"
+download_low_speed_limit="${KOMARI_DOWNLOAD_LOW_SPEED_LIMIT:-1024}"
+download_low_speed_time="${KOMARI_DOWNLOAD_LOW_SPEED_TIME:-10}"
 
 os_type="$(uname -s)"
 case "$os_type" in
@@ -182,14 +186,19 @@ mkdir -p "$target_dir"
 download_file() {
   df_url="$1"
   df_out="$2"
-  df_attempt=1
-  df_max_attempts=3
+  df_attempt="${3:-1}"
+  df_max_attempts="${4:-1}"
   while [ "$df_attempt" -le "$df_max_attempts" ]; do
-    curl -fL -o "$df_out" "$df_url" && return 0
+    curl -fL \
+      --connect-timeout "$download_connect_timeout" \
+      --max-time "$download_max_time" \
+      --speed-limit "$download_low_speed_limit" \
+      --speed-time "$download_low_speed_time" \
+      -o "$df_out" "$df_url" && return 0
     rm -f "$df_out"
-    log_warning "Download failed, retry ${df_attempt}/${df_max_attempts}"
+    log_warning "Download failed or too slow, retry ${df_attempt}/${df_max_attempts}"
     df_attempt=$((df_attempt + 1))
-    sleep 2
+    sleep 1
   done
   return 1
 }
@@ -232,6 +241,13 @@ select_fastest_proxy_url() {
   printf '%s\n' "$best_proxy"
 }
 
+download_attempts_for_url() {
+  case "$1" in
+    https://github.com/*) printf '1\n' ;;
+    *) printf '2\n' ;;
+  esac
+}
+
 try_download_binary() {
   tdb_url="$1"
   tdb_sums_url="$2"
@@ -239,11 +255,14 @@ try_download_binary() {
   tdb_sums_fallback_url="${4:-}"
   tdb_sums_out="${tdb_out}.sha256.$$"
   rm -f "$tdb_sums_out"
+  tdb_binary_attempts="$(download_attempts_for_url "$tdb_url")"
+  tdb_sums_attempts="$(download_attempts_for_url "$tdb_sums_url")"
   log_info "Downloading: ${CYAN}$tdb_url${NC}"
-  download_file "$tdb_url" "$tdb_out" || { rm -f "$tdb_sums_out"; return 1; }
-  if ! download_file "$tdb_sums_url" "$tdb_sums_out"; then
+  download_file "$tdb_url" "$tdb_out" 1 "$tdb_binary_attempts" || { rm -f "$tdb_sums_out"; return 1; }
+  if ! download_file "$tdb_sums_url" "$tdb_sums_out" 1 "$tdb_sums_attempts"; then
     if [ -n "$tdb_sums_fallback_url" ]; then
-      download_file "$tdb_sums_fallback_url" "$tdb_sums_out" || { rm -f "$tdb_out" "$tdb_sums_out"; return 1; }
+      tdb_sums_fallback_attempts="$(download_attempts_for_url "$tdb_sums_fallback_url")"
+      download_file "$tdb_sums_fallback_url" "$tdb_sums_out" 1 "$tdb_sums_fallback_attempts" || { rm -f "$tdb_out" "$tdb_sums_out"; return 1; }
     else
       rm -f "$tdb_out" "$tdb_sums_out"
       return 1

--- a/replace.sh
+++ b/replace.sh
@@ -10,6 +10,10 @@ binary_path=""
 install_dir="/opt/komari"
 tmp=""
 backup=""
+download_connect_timeout="${KOMARI_DOWNLOAD_CONNECT_TIMEOUT:-8}"
+download_max_time="${KOMARI_DOWNLOAD_MAX_TIME:-20}"
+download_low_speed_limit="${KOMARI_DOWNLOAD_LOW_SPEED_LIMIT:-1024}"
+download_low_speed_time="${KOMARI_DOWNLOAD_LOW_SPEED_TIME:-10}"
 
 log() { printf '%s\n' "$*"; }
 err() { printf 'ERROR: %s\n' "$*" >&2; }
@@ -64,24 +68,33 @@ esac
 download() {
   dl_url="$1"
   dl_out="$2"
-  dl_attempt=1
-  dl_max_attempts=3
+  dl_attempt="${3:-1}"
+  dl_max_attempts="${4:-1}"
   if command -v curl >/dev/null 2>&1; then
     while [ "$dl_attempt" -le "$dl_max_attempts" ]; do
-      curl -fL --connect-timeout 20 -o "$dl_out" "$dl_url" && return 0
+      curl -fL \
+        --connect-timeout "$download_connect_timeout" \
+        --max-time "$download_max_time" \
+        --speed-limit "$download_low_speed_limit" \
+        --speed-time "$download_low_speed_time" \
+        -o "$dl_out" "$dl_url" && return 0
       rm -f "$dl_out"
-      log "download failed, retry ${dl_attempt}/${dl_max_attempts}"
+      log "download failed or too slow, retry ${dl_attempt}/${dl_max_attempts}"
       dl_attempt=$((dl_attempt + 1))
-      sleep 2
+      sleep 1
     done
     return 1
   elif command -v wget >/dev/null 2>&1; then
     while [ "$dl_attempt" -le "$dl_max_attempts" ]; do
-      wget -O "$dl_out" "$dl_url" && return 0
+      wget -O "$dl_out" \
+        --connect-timeout="$download_connect_timeout" \
+        --read-timeout="$download_low_speed_time" \
+        --timeout="$download_connect_timeout" \
+        "$dl_url" && return 0
       rm -f "$dl_out"
-      log "download failed, retry ${dl_attempt}/${dl_max_attempts}"
+      log "download failed or too slow, retry ${dl_attempt}/${dl_max_attempts}"
       dl_attempt=$((dl_attempt + 1))
-      sleep 2
+      sleep 1
     done
     return 1
   else
@@ -128,6 +141,13 @@ select_fastest_proxy_url() {
   printf '%s\n' "$best_proxy"
 }
 
+download_attempts_for_url() {
+  case "$1" in
+    https://github.com/*) printf '1\n' ;;
+    *) printf '2\n' ;;
+  esac
+}
+
 try_download_binary() {
   tdb_url="$1"
   tdb_sums_url="$2"
@@ -135,11 +155,14 @@ try_download_binary() {
   tdb_sums_fallback_url="${4:-}"
   tdb_sums_out="${tdb_out}.sha256.$$"
   rm -f "$tdb_sums_out"
+  tdb_binary_attempts="$(download_attempts_for_url "$tdb_url")"
+  tdb_sums_attempts="$(download_attempts_for_url "$tdb_sums_url")"
   log "download: ${tdb_url}"
-  download "$tdb_url" "$tdb_out" || { rm -f "$tdb_sums_out"; return 1; }
-  if ! download "$tdb_sums_url" "$tdb_sums_out"; then
+  download "$tdb_url" "$tdb_out" 1 "$tdb_binary_attempts" || { rm -f "$tdb_sums_out"; return 1; }
+  if ! download "$tdb_sums_url" "$tdb_sums_out" 1 "$tdb_sums_attempts"; then
     if [ -n "$tdb_sums_fallback_url" ]; then
-      download "$tdb_sums_fallback_url" "$tdb_sums_out" || { rm -f "$tdb_out" "$tdb_sums_out"; return 1; }
+      tdb_sums_fallback_attempts="$(download_attempts_for_url "$tdb_sums_fallback_url")"
+      download "$tdb_sums_fallback_url" "$tdb_sums_out" 1 "$tdb_sums_fallback_attempts" || { rm -f "$tdb_out" "$tdb_sums_out"; return 1; }
     else
       rm -f "$tdb_out" "$tdb_sums_out"
       return 1

--- a/test/script_harness.sh
+++ b/test/script_harness.sh
@@ -31,13 +31,13 @@ not_ok() {
 assert_file_contains() {
   file="$1"
   text="$2"
-  grep -F "$text" "$file" >/dev/null 2>&1
+  grep -F -- "$text" "$file" >/dev/null 2>&1
 }
 
 assert_file_not_contains() {
   file="$1"
   text="$2"
-  ! grep -F "$text" "$file" >/dev/null 2>&1
+  ! grep -F -- "$text" "$file" >/dev/null 2>&1
 }
 
 setup_case() {
@@ -88,6 +88,7 @@ write_fakes() {
 out=""
 fmt=""
 url=""
+orig_args="$*"
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -o) out="$2"; shift 2 ;;
@@ -97,6 +98,7 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift ;;
   esac
 done
+printf 'curl-args %s\n' "$orig_args" >> "$SCRIPT_TEST_LOG"
 printf 'curl %s\n' "$url" >> "$SCRIPT_TEST_LOG"
 case "$out:$fmt" in
   /dev/null:*) printf '0.010'; exit 0 ;;
@@ -111,6 +113,9 @@ case "$url" in
 esac
 if [ "${SCRIPT_TEST_DIRECT_BINARY_FAIL:-0}" = 1 ] && [ "$is_direct" = 1 ] && [ "$is_sums" = 0 ]; then
   exit 22
+fi
+if [ "${SCRIPT_TEST_DIRECT_BINARY_SLOW:-0}" = 1 ] && [ "$is_direct" = 1 ] && [ "$is_sums" = 0 ]; then
+  exit 28
 fi
 if [ "${SCRIPT_TEST_DIRECT_SUMS_FAIL:-0}" = 1 ] && [ "$is_direct" = 1 ] && [ "$is_sums" = 1 ]; then
   exit 22
@@ -211,6 +216,7 @@ run_env() {
     SCRIPT_TEST_ASSET="$ASSET" \
     SCRIPT_TEST_DIRECT_BINARY_FAIL="${SCRIPT_TEST_DIRECT_BINARY_FAIL:-0}" \
     SCRIPT_TEST_DIRECT_SUMS_FAIL="${SCRIPT_TEST_DIRECT_SUMS_FAIL:-0}" \
+    SCRIPT_TEST_DIRECT_BINARY_SLOW="${SCRIPT_TEST_DIRECT_BINARY_SLOW:-0}" \
     SCRIPT_TEST_SYSTEMD_CAT="${SCRIPT_TEST_SYSTEMD_CAT:-0}" \
     SCRIPT_TEST_TARGET="${SCRIPT_TEST_TARGET:-}" \
     SCRIPT_TEST_SYSTEMD_RESTART_FAIL="${SCRIPT_TEST_SYSTEMD_RESTART_FAIL:-0}" \
@@ -234,6 +240,17 @@ test_install_proxy_fallback_success() {
   SCRIPT_TEST_DIRECT_BINARY_FAIL=1 run_env sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR" --install-service-name "$SERVICE" -e http://server -t token >/dev/null
   [ -x "$INSTALL_DIR/agent" ] &&
     assert_file_contains "$LOG" "curl https://gh.llkk.cc/https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET"
+}
+
+test_install_slow_direct_switches_to_proxy_once() {
+  setup_case install_slow_direct
+  SCRIPT_TEST_DIRECT_BINARY_SLOW=1 run_env sh "$ROOT/install.sh" --install-dir "$INSTALL_DIR" --install-service-name "$SERVICE" -e http://server -t token >/dev/null
+  direct_count="$(grep -Fx "curl https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET" "$LOG" | wc -l | tr -d ' ')"
+  [ "$direct_count" = 1 ] &&
+    assert_file_contains "$LOG" "curl https://gh.llkk.cc/https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET" &&
+    assert_file_contains "$LOG" "--max-time 20" &&
+    assert_file_contains "$LOG" "--speed-limit 1024" &&
+    assert_file_contains "$LOG" "--speed-time 10"
 }
 
 test_install_explicit_proxy_success() {
@@ -279,6 +296,20 @@ test_replace_proxy_fallback_success() {
   SCRIPT_TEST_DIRECT_BINARY_FAIL=1 run_env sh "$ROOT/replace.sh" --binary "$target" --service "$SERVICE" >/dev/null
   assert_file_contains "$target" "komari test agent" &&
     assert_file_contains "$LOG" "curl https://gh.llkk.cc/https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET"
+}
+
+test_replace_slow_direct_switches_to_proxy_once() {
+  setup_case replace_slow_direct
+  target="$INSTALL_DIR/agent"
+  printf 'old-agent\n' > "$target"
+  chmod 0755 "$target"
+  SCRIPT_TEST_DIRECT_BINARY_SLOW=1 run_env sh "$ROOT/replace.sh" --binary "$target" --service "$SERVICE" >/dev/null
+  direct_count="$(grep -Fx "curl https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET" "$LOG" | wc -l | tr -d ' ')"
+  [ "$direct_count" = 1 ] &&
+    assert_file_contains "$target" "komari test agent" &&
+    assert_file_contains "$LOG" "curl https://gh.llkk.cc/https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET" &&
+    assert_file_contains "$LOG" "--max-time 20" &&
+    assert_file_contains "$LOG" "--speed-limit 1024"
 }
 
 test_replace_proxy_checksum_fallback_success() {
@@ -354,6 +385,21 @@ test_update_binary_direct_success_no_backup() {
     assert_no_backup_files "$INSTALL_DIR"
 }
 
+test_update_binary_slow_direct_switches_to_proxy_once() {
+  setup_case update_binary_slow_direct
+  target="$INSTALL_DIR/agent"
+  printf 'old-agent\n' > "$target"
+  chmod 0755 "$target"
+  SCRIPT_TEST_TARGET="$target" SCRIPT_TEST_SYSTEMD_CAT=1 SCRIPT_TEST_DIRECT_BINARY_SLOW=1 run_env sh "$ROOT/update-binary.sh" --binary "$target" --service "$SERVICE" >/dev/null
+  direct_count="$(grep -Fx "curl https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET" "$LOG" | wc -l | tr -d ' ')"
+  [ "$direct_count" = 1 ] &&
+    assert_file_contains "$target" "komari test agent" &&
+    assert_file_contains "$LOG" "curl https://gh.llkk.cc/https://github.com/luodaoyi/komari-zig-agent/releases/latest/download/$ASSET" &&
+    assert_file_contains "$LOG" "--max-time 20" &&
+    assert_file_contains "$LOG" "--speed-limit 1024" &&
+    assert_no_backup_files "$INSTALL_DIR"
+}
+
 test_update_binary_systemd_discovery_preserves_service() {
   setup_case update_binary_systemd_find
   target="$INSTALL_DIR/agent"
@@ -419,17 +465,20 @@ mkdir -p "$BASE"
 
 run_test test_install_direct_success
 run_test test_install_proxy_fallback_success
+run_test test_install_slow_direct_switches_to_proxy_once
 run_test test_install_explicit_proxy_success
 run_test test_install_checksum_failure
 run_test test_install_preflight_failure
 run_test test_replace_direct_success
 run_test test_replace_proxy_fallback_success
+run_test test_replace_slow_direct_switches_to_proxy_once
 run_test test_replace_proxy_checksum_fallback_success
 run_test test_replace_checksum_failure_keeps_old
 run_test test_replace_preflight_failure_keeps_old
 run_test test_replace_start_failure_rolls_back
 run_test test_replace_systemd_discovery
 run_test test_update_binary_direct_success_no_backup
+run_test test_update_binary_slow_direct_switches_to_proxy_once
 run_test test_update_binary_systemd_discovery_preserves_service
 run_test test_update_binary_checksum_failure_keeps_old_no_backup
 run_test test_update_binary_preflight_failure_keeps_old_no_backup

--- a/update-binary.sh
+++ b/update-binary.sh
@@ -9,6 +9,10 @@ github_proxy_list="${KOMARI_GITHUB_PROXIES:-https://gh.llkk.cc https://gh-proxy.
 binary_path=""
 install_dir="/opt/komari"
 tmp=""
+download_connect_timeout="${KOMARI_DOWNLOAD_CONNECT_TIMEOUT:-8}"
+download_max_time="${KOMARI_DOWNLOAD_MAX_TIME:-20}"
+download_low_speed_limit="${KOMARI_DOWNLOAD_LOW_SPEED_LIMIT:-1024}"
+download_low_speed_time="${KOMARI_DOWNLOAD_LOW_SPEED_TIME:-10}"
 
 log() { printf '%s\n' "$*"; }
 err() { printf 'ERROR: %s\n' "$*" >&2; }
@@ -65,24 +69,33 @@ esac
 download() {
   dl_url="$1"
   dl_out="$2"
-  dl_attempt=1
-  dl_max_attempts=3
+  dl_attempt="${3:-1}"
+  dl_max_attempts="${4:-1}"
   if command -v curl >/dev/null 2>&1; then
     while [ "$dl_attempt" -le "$dl_max_attempts" ]; do
-      curl -fL --connect-timeout 20 -o "$dl_out" "$dl_url" && return 0
+      curl -fL \
+        --connect-timeout "$download_connect_timeout" \
+        --max-time "$download_max_time" \
+        --speed-limit "$download_low_speed_limit" \
+        --speed-time "$download_low_speed_time" \
+        -o "$dl_out" "$dl_url" && return 0
       rm -f "$dl_out"
-      log "download failed, retry ${dl_attempt}/${dl_max_attempts}"
+      log "download failed or too slow, retry ${dl_attempt}/${dl_max_attempts}"
       dl_attempt=$((dl_attempt + 1))
-      sleep 2
+      sleep 1
     done
     return 1
   elif command -v wget >/dev/null 2>&1; then
     while [ "$dl_attempt" -le "$dl_max_attempts" ]; do
-      wget -O "$dl_out" "$dl_url" && return 0
+      wget -O "$dl_out" \
+        --connect-timeout="$download_connect_timeout" \
+        --read-timeout="$download_low_speed_time" \
+        --timeout="$download_connect_timeout" \
+        "$dl_url" && return 0
       rm -f "$dl_out"
-      log "download failed, retry ${dl_attempt}/${dl_max_attempts}"
+      log "download failed or too slow, retry ${dl_attempt}/${dl_max_attempts}"
       dl_attempt=$((dl_attempt + 1))
-      sleep 2
+      sleep 1
     done
     return 1
   else
@@ -129,6 +142,13 @@ select_fastest_proxy_url() {
   printf '%s\n' "$best_proxy"
 }
 
+download_attempts_for_url() {
+  case "$1" in
+    https://github.com/*) printf '1\n' ;;
+    *) printf '2\n' ;;
+  esac
+}
+
 try_download_binary() {
   tdb_url="$1"
   tdb_sums_url="$2"
@@ -136,11 +156,14 @@ try_download_binary() {
   tdb_sums_fallback_url="${4:-}"
   tdb_sums_out="${tdb_out}.sha256.$$"
   rm -f "$tdb_sums_out"
+  tdb_binary_attempts="$(download_attempts_for_url "$tdb_url")"
+  tdb_sums_attempts="$(download_attempts_for_url "$tdb_sums_url")"
   log "download: ${tdb_url}"
-  download "$tdb_url" "$tdb_out" || { rm -f "$tdb_sums_out"; return 1; }
-  if ! download "$tdb_sums_url" "$tdb_sums_out"; then
+  download "$tdb_url" "$tdb_out" 1 "$tdb_binary_attempts" || { rm -f "$tdb_sums_out"; return 1; }
+  if ! download "$tdb_sums_url" "$tdb_sums_out" 1 "$tdb_sums_attempts"; then
     if [ -n "$tdb_sums_fallback_url" ]; then
-      download "$tdb_sums_fallback_url" "$tdb_sums_out" || { rm -f "$tdb_out" "$tdb_sums_out"; return 1; }
+      tdb_sums_fallback_attempts="$(download_attempts_for_url "$tdb_sums_fallback_url")"
+      download "$tdb_sums_fallback_url" "$tdb_sums_out" 1 "$tdb_sums_fallback_attempts" || { rm -f "$tdb_out" "$tdb_sums_out"; return 1; }
     else
       rm -f "$tdb_out" "$tdb_sums_out"
       return 1


### PR DESCRIPTION
## Summary
- Add fail-fast download limits to install, replace, and update-binary scripts.
- Treat slow downloads as failures using curl max-time and low-speed detection.
- Try direct GitHub only once, then immediately probe and switch to GitHub mirror proxies.
- Keep proxy downloads retryable while preserving SHA256 and binary preflight validation.
- Add script harness regressions for install/replace/update-binary slow-direct fallback.

## Behavior
Defaults can be overridden by environment variables:
- `KOMARI_DOWNLOAD_CONNECT_TIMEOUT` default `8`
- `KOMARI_DOWNLOAD_MAX_TIME` default `20`
- `KOMARI_DOWNLOAD_LOW_SPEED_LIMIT` default `1024`
- `KOMARI_DOWNLOAD_LOW_SPEED_TIME` default `10`

## Tests
- `sh -n install.sh replace.sh update-binary.sh test/script_harness.sh`
- `sh test/script_harness.sh` => 20 passed, 0 failed
- `zig build test`
- `zig build -Doptimize=ReleaseSmall -Dversion=dev -Dtarget=x86_64-linux-musl`
- `zig build -Doptimize=ReleaseSmall -Dversion=dev`
- `python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --terminal --no-exec`
