### PR TITLE
fix: align ping latency detection with raw icmp behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,26 @@ jobs:
         run: zig build test
       - name: Build native agent
         run: zig build -Doptimize=ReleaseSmall -Dversion=dev
+      - name: Native ICMP ping smoke
+        if: runner.os == 'Linux'
+        run: |
+          set -eu
+          raw="$(zig-out/bin/komari-agent ping-test icmp 127.0.0.1 '' raw)"
+          auto="$(zig-out/bin/komari-agent ping-test icmp 127.0.0.1)"
+          echo "raw=$raw auto=$auto"
+          test "$raw" -ge 0
+          test "$auto" -ge 0
+          range="$(sysctl -n net.ipv4.ping_group_range 2>/dev/null || true)"
+          datagram="$(zig-out/bin/komari-agent ping-test icmp 127.0.0.1 '' datagram)"
+          echo "ping_group_range=$range datagram=$datagram"
+          if [ "$datagram" -lt 0 ] && [ -n "$range" ]; then
+            set -- $range
+            gid="$(id -g)"
+            if [ "$1" -le "$gid" ] && [ "$gid" -le "$2" ]; then
+              echo "datagram ping socket is allowed for this gid but ping-test failed" >&2
+              exit 1
+            fi
+          fi
       - name: Native mock panel business smoke
         if: runner.os != 'Windows'
         run: python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --cf --no-exec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,22 +36,15 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -eu
-          raw="$(zig-out/bin/komari-agent ping-test icmp 127.0.0.1 '' raw)"
-          auto="$(zig-out/bin/komari-agent ping-test icmp 127.0.0.1)"
+          sudo sysctl -w net.ipv4.ping_group_range='0 2147483647' >/dev/null
+          raw="$(sudo zig-out/bin/komari-agent ping-test icmp 127.0.0.1 '' raw)"
+          auto="$(sudo zig-out/bin/komari-agent ping-test icmp 127.0.0.1)"
           echo "raw=$raw auto=$auto"
           test "$raw" -ge 0
           test "$auto" -ge 0
-          range="$(sysctl -n net.ipv4.ping_group_range 2>/dev/null || true)"
           datagram="$(zig-out/bin/komari-agent ping-test icmp 127.0.0.1 '' datagram)"
-          echo "ping_group_range=$range datagram=$datagram"
-          if [ "$datagram" -lt 0 ] && [ -n "$range" ]; then
-            set -- $range
-            gid="$(id -g)"
-            if [ "$1" -le "$gid" ] && [ "$gid" -le "$2" ]; then
-              echo "datagram ping socket is allowed for this gid but ping-test failed" >&2
-              exit 1
-            fi
-          fi
+          echo "datagram=$datagram"
+          test "$datagram" -ge 0
       - name: Native mock panel business smoke
         if: runner.os != 'Windows'
         run: python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --cf --no-exec

--- a/src/main.zig
+++ b/src/main.zig
@@ -120,7 +120,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
 fn runPingDiagnostic(allocator: std.mem.Allocator, args: []const []const u8) !bool {
     if (args.len < 4 or !std.mem.eql(u8, args[1], "ping-test")) return false;
     const custom_dns = if (args.len >= 5) args[4] else "";
-    const value = ping.measure(allocator, args[2], args[3], custom_dns);
+    const icmp_mode = if (args.len >= 6) args[5] else "";
+    const value = ping.measureDiagnostic(allocator, args[2], args[3], custom_dns, icmp_mode);
     var stdout_buf: [256]u8 = undefined;
     var stdout = compat.fileWriter(std.Io.File.stdout(), &stdout_buf);
     defer stdout.flush() catch {};

--- a/src/protocol/ping.zig
+++ b/src/protocol/ping.zig
@@ -112,9 +112,13 @@ fn icmpPing(allocator: std.mem.Allocator, target: []const u8, custom_dns: []cons
 
 fn icmpPingAddress(addr: net.Address) !i64 {
     if (net.isIpv6(addr)) return icmp6PingAddress(addr);
-    const flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
-    const sock = compat.socket(std.posix.AF.INET, flags, std.posix.IPPROTO.ICMP) catch |err| switch (err) {
-        error.AccessDenied => try compat.socket(std.posix.AF.INET, std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0, std.posix.IPPROTO.ICMP),
+    const dgram_flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
+    var privileged = false;
+    const sock = compat.socket(std.posix.AF.INET, dgram_flags, std.posix.IPPROTO.ICMP) catch |err| switch (err) {
+        error.AccessDenied => blk: {
+            privileged = true;
+            break :blk try compat.socket(std.posix.AF.INET, std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0, std.posix.IPPROTO.ICMP);
+        },
         else => return err,
     };
     defer compat.closeFd(sock);
@@ -127,6 +131,7 @@ fn icmpPingAddress(addr: net.Address) !i64 {
     std.mem.writeInt(u16, packet[4..6], ident, .big);
     std.mem.writeInt(u16, packet[6..8], seq, .big);
     std.mem.writeInt(u64, packet[8..16], @truncate(@as(u128, @bitCast(compat.nanoTimestamp()))), .big);
+    const payload = packet[8..16];
     const csum = icmpChecksum(&packet);
     std.mem.writeInt(u16, packet[2..4], csum, .big);
 
@@ -140,15 +145,19 @@ fn icmpPingAddress(addr: net.Address) !i64 {
         if (ready == 0) return error.Timeout;
         var buf: [1500]u8 = undefined;
         const n = try compat.recvFrom(sock, &buf);
-        if (isEchoReply(buf[0..n], seq)) return compat.milliTimestamp() - start;
+        if (isEchoReply(buf[0..n], ident, seq, payload, privileged)) return compat.milliTimestamp() - start;
     }
     return error.Timeout;
 }
 
 fn icmp6PingAddress(addr: net.Address) !i64 {
-    const flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
-    const sock = compat.socket(std.posix.AF.INET6, flags, std.posix.IPPROTO.ICMPV6) catch |err| switch (err) {
-        error.AccessDenied => try compat.socket(std.posix.AF.INET6, std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0, std.posix.IPPROTO.ICMPV6),
+    const dgram_flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
+    var privileged = false;
+    const sock = compat.socket(std.posix.AF.INET6, dgram_flags, std.posix.IPPROTO.ICMPV6) catch |err| switch (err) {
+        error.AccessDenied => blk: {
+            privileged = true;
+            break :blk try compat.socket(std.posix.AF.INET6, std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0, std.posix.IPPROTO.ICMPV6);
+        },
         else => return err,
     };
     defer compat.closeFd(sock);
@@ -161,6 +170,7 @@ fn icmp6PingAddress(addr: net.Address) !i64 {
     std.mem.writeInt(u16, packet[4..6], ident, .big);
     std.mem.writeInt(u16, packet[6..8], seq, .big);
     std.mem.writeInt(u64, packet[8..16], @truncate(@as(u128, @bitCast(compat.nanoTimestamp()))), .big);
+    const payload = packet[8..16];
 
     const start = compat.milliTimestamp();
     const sa = net.sockAddr(addr);
@@ -172,35 +182,47 @@ fn icmp6PingAddress(addr: net.Address) !i64 {
         if (ready == 0) return error.Timeout;
         var buf: [1500]u8 = undefined;
         const n = try compat.recvFrom(sock, &buf);
-        if (isEchoReply6(buf[0..n], seq)) return compat.milliTimestamp() - start;
+        if (isEchoReply6(buf[0..n], ident, seq, payload, privileged)) return compat.milliTimestamp() - start;
     }
     return error.Timeout;
 }
 
-fn isEchoReply(bytes: []const u8, seq: u16) bool {
+fn isEchoReply(bytes: []const u8, ident: u16, seq: u16, payload: []const u8, privileged: bool) bool {
     var off: usize = 0;
     if (bytes.len >= 20 and (bytes[0] >> 4) == 4) off = (bytes[0] & 0x0f) * 4;
     if (bytes.len < off + 8) return false;
     if (bytes[off] != 0 or bytes[off + 1] != 0) return false;
+    if (privileged) {
+        const got_ident = (@as(u16, bytes[off + 4]) << 8) | bytes[off + 5];
+        if (got_ident != ident) return false;
+    }
     const got_seq = (@as(u16, bytes[off + 6]) << 8) | bytes[off + 7];
-    return got_seq == seq;
+    if (got_seq != seq) return false;
+    const body = bytes[off + 8 ..];
+    return body.len == payload.len and std.mem.eql(u8, body, payload);
 }
 
-fn isEchoReply6(bytes: []const u8, seq: u16) bool {
+fn isEchoReply6(bytes: []const u8, ident: u16, seq: u16, payload: []const u8, privileged: bool) bool {
     var off: usize = 0;
     if (bytes.len >= 40 and (bytes[0] >> 4) == 6) off = 40;
     if (bytes.len < off + 8) return false;
     if (bytes[off] != 129 or bytes[off + 1] != 0) return false;
+    if (privileged) {
+        const got_ident = (@as(u16, bytes[off + 4]) << 8) | bytes[off + 5];
+        if (got_ident != ident) return false;
+    }
     const got_seq = (@as(u16, bytes[off + 6]) << 8) | bytes[off + 7];
-    return got_seq == seq;
+    if (got_seq != seq) return false;
+    const body = bytes[off + 8 ..];
+    return body.len == payload.len and std.mem.eql(u8, body, payload);
 }
 
-pub fn isIcmpEchoReplyForTest(bytes: []const u8, _: u16, seq: u16) bool {
-    return isEchoReply(bytes, seq);
+pub fn isIcmpEchoReplyForTest(bytes: []const u8, ident: u16, seq: u16, payload: []const u8, privileged: bool) bool {
+    return isEchoReply(bytes, ident, seq, payload, privileged);
 }
 
-pub fn isIcmp6EchoReplyForTest(bytes: []const u8, _: u16, seq: u16) bool {
-    return isEchoReply6(bytes, seq);
+pub fn isIcmp6EchoReplyForTest(bytes: []const u8, ident: u16, seq: u16, payload: []const u8, privileged: bool) bool {
+    return isEchoReply6(bytes, ident, seq, payload, privileged);
 }
 
 pub fn parseTcpTarget(target: []const u8) !TcpTarget {

--- a/src/protocol/ping.zig
+++ b/src/protocol/ping.zig
@@ -18,6 +18,12 @@ const PingKind = enum {
     icmp,
 };
 
+const IcmpMode = enum {
+    auto,
+    raw,
+    datagram,
+};
+
 pub fn allocPingResultJson(allocator: std.mem.Allocator, task_id: u64, ping_type: []const u8, value: i64, finished_at: []const u8) ![]const u8 {
     var out = std.Io.Writer.Allocating.init(allocator);
     defer out.deinit();
@@ -31,15 +37,23 @@ pub fn allocPingResultJson(allocator: std.mem.Allocator, task_id: u64, ping_type
 }
 
 pub fn measure(allocator: std.mem.Allocator, ping_type: []const u8, target: []const u8, custom_dns: []const u8) i64 {
+    return measureWithIcmpMode(allocator, ping_type, target, custom_dns, .auto);
+}
+
+pub fn measureDiagnostic(allocator: std.mem.Allocator, ping_type: []const u8, target: []const u8, custom_dns: []const u8, icmp_mode: []const u8) i64 {
+    return measureWithIcmpMode(allocator, ping_type, target, custom_dns, parseIcmpMode(icmp_mode) orelse .auto);
+}
+
+fn measureWithIcmpMode(allocator: std.mem.Allocator, ping_type: []const u8, target: []const u8, custom_dns: []const u8, icmp_mode: IcmpMode) i64 {
     const kind = normalizePingType(ping_type) orelse return -1;
     const high_latency_threshold: i64 = 1000;
-    const first = measureOnce(allocator, kind, target, custom_dns);
+    const first = measureOnce(allocator, kind, target, custom_dns, icmp_mode);
     if (first < 0) return -1;
     if (first <= high_latency_threshold) return first;
     var latency = first;
     var attempt: u8 = 0;
     while (attempt < 3) : (attempt += 1) {
-        const value = measureOnce(allocator, kind, target, custom_dns);
+        const value = measureOnce(allocator, kind, target, custom_dns, icmp_mode);
         if (value < 0) return -1;
         latency = value;
         if (latency <= high_latency_threshold) return latency;
@@ -47,12 +61,19 @@ pub fn measure(allocator: std.mem.Allocator, ping_type: []const u8, target: []co
     return -1;
 }
 
-fn measureOnce(allocator: std.mem.Allocator, kind: PingKind, target: []const u8, custom_dns: []const u8) i64 {
+fn measureOnce(allocator: std.mem.Allocator, kind: PingKind, target: []const u8, custom_dns: []const u8, icmp_mode: IcmpMode) i64 {
     return switch (kind) {
         .tcp => tcpPing(allocator, target, custom_dns) catch -1,
         .http => httpPing(allocator, target, custom_dns) catch -1,
-        .icmp => icmpPing(allocator, target, custom_dns) catch -1,
+        .icmp => icmpPing(allocator, target, custom_dns, icmp_mode) catch -1,
     };
+}
+
+fn parseIcmpMode(value: []const u8) ?IcmpMode {
+    if (value.len == 0 or std.ascii.eqlIgnoreCase(value, "auto")) return .auto;
+    if (std.ascii.eqlIgnoreCase(value, "raw") or std.ascii.eqlIgnoreCase(value, "privileged")) return .raw;
+    if (std.ascii.eqlIgnoreCase(value, "datagram") or std.ascii.eqlIgnoreCase(value, "dgram") or std.ascii.eqlIgnoreCase(value, "ping_socket")) return .datagram;
+    return null;
 }
 
 fn normalizePingType(ping_type: []const u8) ?PingKind {
@@ -96,13 +117,13 @@ pub fn icmpChecksum(bytes: []const u8) u16 {
     return @as(u16, @intCast(~sum & 0xffff));
 }
 
-fn icmpPing(allocator: std.mem.Allocator, target: []const u8, custom_dns: []const u8) !i64 {
+fn icmpPing(allocator: std.mem.Allocator, target: []const u8, custom_dns: []const u8, icmp_mode: IcmpMode) !i64 {
     if (builtin.os.tag == .windows) return error.Unsupported;
     const addrs = try dns.resolveHost(allocator, parseHostOnly(target), 0, custom_dns);
     defer allocator.free(addrs);
     for (addrs) |addr| {
         if (!net.isIpv4(addr) and !net.isIpv6(addr)) continue;
-        return icmpPingAddress(addr) catch |err| switch (err) {
+        return icmpPingAddress(addr, icmp_mode) catch |err| switch (err) {
             error.AccessDenied => continue,
             else => continue,
         };
@@ -110,17 +131,11 @@ fn icmpPing(allocator: std.mem.Allocator, target: []const u8, custom_dns: []cons
     return -1;
 }
 
-fn icmpPingAddress(addr: net.Address) !i64 {
-    if (net.isIpv6(addr)) return icmp6PingAddress(addr);
-    const dgram_flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
-    var privileged = false;
-    const sock = compat.socket(std.posix.AF.INET, dgram_flags, std.posix.IPPROTO.ICMP) catch |err| switch (err) {
-        error.AccessDenied => blk: {
-            privileged = true;
-            break :blk try compat.socket(std.posix.AF.INET, std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0, std.posix.IPPROTO.ICMP);
-        },
-        else => return err,
-    };
+fn icmpPingAddress(addr: net.Address, icmp_mode: IcmpMode) !i64 {
+    if (net.isIpv6(addr)) return icmp6PingAddress(addr, icmp_mode);
+    const opened = try openIcmp4Socket(icmp_mode);
+    const sock = opened.fd;
+    const privileged = opened.privileged;
     defer compat.closeFd(sock);
 
     var packet: [16]u8 = .{0} ** 16;
@@ -150,16 +165,31 @@ fn icmpPingAddress(addr: net.Address) !i64 {
     return error.Timeout;
 }
 
-fn icmp6PingAddress(addr: net.Address) !i64 {
+const IcmpSocket = struct {
+    fd: std.posix.fd_t,
+    privileged: bool,
+};
+
+fn openIcmp4Socket(icmp_mode: IcmpMode) !IcmpSocket {
     const dgram_flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
-    var privileged = false;
-    const sock = compat.socket(std.posix.AF.INET6, dgram_flags, std.posix.IPPROTO.ICMPV6) catch |err| switch (err) {
-        error.AccessDenied => blk: {
-            privileged = true;
-            break :blk try compat.socket(std.posix.AF.INET6, std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0, std.posix.IPPROTO.ICMPV6);
+    const raw_flags = std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
+    return switch (icmp_mode) {
+        .raw => .{ .fd = try compat.socket(std.posix.AF.INET, raw_flags, std.posix.IPPROTO.ICMP), .privileged = true },
+        .datagram => .{ .fd = try compat.socket(std.posix.AF.INET, dgram_flags, std.posix.IPPROTO.ICMP), .privileged = false },
+        .auto => blk: {
+            const raw = compat.socket(std.posix.AF.INET, raw_flags, std.posix.IPPROTO.ICMP) catch |err| switch (err) {
+                error.AccessDenied => break :blk .{ .fd = try compat.socket(std.posix.AF.INET, dgram_flags, std.posix.IPPROTO.ICMP), .privileged = false },
+                else => return err,
+            };
+            break :blk .{ .fd = raw, .privileged = true };
         },
-        else => return err,
     };
+}
+
+fn icmp6PingAddress(addr: net.Address, icmp_mode: IcmpMode) !i64 {
+    const opened = try openIcmp6Socket(icmp_mode);
+    const sock = opened.fd;
+    const privileged = opened.privileged;
     defer compat.closeFd(sock);
 
     var packet: [16]u8 = .{0} ** 16;
@@ -185,6 +215,23 @@ fn icmp6PingAddress(addr: net.Address) !i64 {
         if (isEchoReply6(buf[0..n], ident, seq, payload, privileged)) return compat.milliTimestamp() - start;
     }
     return error.Timeout;
+}
+
+
+fn openIcmp6Socket(icmp_mode: IcmpMode) !IcmpSocket {
+    const dgram_flags = std.posix.SOCK.DGRAM | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
+    const raw_flags = std.posix.SOCK.RAW | if (builtin.os.tag == .linux) std.posix.SOCK.CLOEXEC else 0;
+    return switch (icmp_mode) {
+        .raw => .{ .fd = try compat.socket(std.posix.AF.INET6, raw_flags, std.posix.IPPROTO.ICMPV6), .privileged = true },
+        .datagram => .{ .fd = try compat.socket(std.posix.AF.INET6, dgram_flags, std.posix.IPPROTO.ICMPV6), .privileged = false },
+        .auto => blk: {
+            const raw = compat.socket(std.posix.AF.INET6, raw_flags, std.posix.IPPROTO.ICMPV6) catch |err| switch (err) {
+                error.AccessDenied => break :blk .{ .fd = try compat.socket(std.posix.AF.INET6, dgram_flags, std.posix.IPPROTO.ICMPV6), .privileged = false },
+                else => return err,
+            };
+            break :blk .{ .fd = raw, .privileged = true };
+        },
+    };
 }
 
 fn isEchoReply(bytes: []const u8, ident: u16, seq: u16, payload: []const u8, privileged: bool) bool {

--- a/test/ping_test.zig
+++ b/test/ping_test.zig
@@ -50,16 +50,39 @@ test "icmp echo reply parser accepts linux datagram socket rewritten identifier"
     packet[25] = 0x78;
     packet[26] = 0;
     packet[27] = 1;
-    try std.testing.expect(ping.isIcmpEchoReplyForTest(&packet, 0x1234, 1));
+    const payload = &[_]u8{ 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22 };
+    // Append expected payload after the ICMP header.
+    var packet_with_payload = [_]u8{0} ** 36;
+    @memcpy(packet_with_payload[0..28], &packet);
+    @memcpy(packet_with_payload[28..36], payload);
+    try std.testing.expect(ping.isIcmpEchoReplyForTest(&packet_with_payload, 0x1234, 1, payload, false));
+    try std.testing.expect(!ping.isIcmpEchoReplyForTest(&packet_with_payload, 0x1234, 1, payload, true));
 }
 
 test "icmp6 echo reply parser accepts ipv6 payload" {
-    var packet = [_]u8{0} ** 48;
+    var packet = [_]u8{0} ** 56;
     packet[0] = 0x60;
     packet[40] = 129;
     packet[41] = 0;
     packet[44] = 0x12;
     packet[45] = 0x34;
     packet[47] = 1;
-    try std.testing.expect(ping.isIcmp6EchoReplyForTest(&packet, 0x1234, 1));
+    const payload = &[_]u8{ 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80 };
+    @memcpy(packet[48..56], payload);
+    try std.testing.expect(ping.isIcmp6EchoReplyForTest(&packet, 0x1234, 1, payload, false));
+}
+
+test "icmp echo reply parser rejects mismatched payload even when seq matches" {
+    var packet = [_]u8{0} ** 36;
+    packet[0] = 0x45;
+    packet[20] = 0;
+    packet[21] = 0;
+    packet[24] = 0;
+    packet[25] = 1;
+    packet[26] = 0;
+    packet[27] = 1;
+    const payload = &[_]u8{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    @memcpy(packet[28..36], payload);
+    const wrong = &[_]u8{ 8, 7, 6, 5, 4, 3, 2, 1 };
+    try std.testing.expect(!ping.isIcmpEchoReplyForTest(&packet, 0x1234, 1, wrong, false));
 }


### PR DESCRIPTION
## Summary
- Align ICMP latency detection with the Go agent's behavior: prefer privileged raw ICMP and only fall back to Linux ping datagram sockets when raw is denied.
- Match ICMP replies by payload token as well as sequence number, so rewritten datagram identifiers do not break valid replies and stray packets do not get misclassified.
- Keep raw mode strict on ICMP identifier matching.
- Add regression tests for rewritten identifiers, payload mismatch rejection, and IPv6 payload matching.

## Verification
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseSmall -Dversion=dev`
