### PR TITLE
[codex] fix 32-bit icmp counter compatibility

### DIFF
--- a/src/protocol/ping.zig
+++ b/src/protocol/ping.zig
@@ -25,8 +25,9 @@ const IcmpMode = enum {
 };
 
 // Concurrent ICMP tasks need unique request markers so replies are not
-// accidentally consumed by a sibling socket on the same host.
-var icmp_probe_counter = std.atomic.Value(u64).init(1);
+// accidentally consumed by a sibling socket on the same host. Keep the atomic
+// counter 32-bit so cross-compiles to 32-bit targets can still use fetchAdd.
+var icmp_probe_counter = std.atomic.Value(u32).init(1);
 
 const IcmpProbeIdentity = struct {
     ident: u16,
@@ -148,7 +149,7 @@ fn icmpProbeIdentityFromNonce(nonce: u64) IcmpProbeIdentity {
 }
 
 fn nextIcmpProbeIdentity() IcmpProbeIdentity {
-    return icmpProbeIdentityFromNonce(icmp_probe_counter.fetchAdd(1, .monotonic));
+    return icmpProbeIdentityFromNonce(@as(u64, icmp_probe_counter.fetchAdd(1, .monotonic)));
 }
 
 pub fn icmpProbeIdentityForTest(nonce: u64) IcmpProbeIdentity {


### PR DESCRIPTION
## What changed
- switch the concurrent ICMP probe counter from `u64` atomic to `u32`
- cast back to `u64` only when deriving the probe identity
- keep the unique ICMP identity behavior while restoring 32-bit target compatibility

## Why
The previous fix for concurrent ICMP tasks introduced `std.atomic.Value(u64).fetchAdd(...)`. That compiles on 64-bit targets, but Zig 0.16 rejects that atomic add on some 32-bit targets, which broke the PR build matrix for `mips-linux-musleabi` and `x86-freebsd`.

## Impact
- restores CI for the 32-bit build targets
- keeps the earlier concurrent ICMP task fix intact
- does not change task protocol or panel behavior

## Validation
- `zig build test`
- `zig build -Doptimize=ReleaseSmall -Dversion=dev -Dtarget=mips-linux-musleabi`
- `zig build -Doptimize=ReleaseSmall -Dversion=dev -Dtarget=x86-freebsd`
