### PR TITLE
fix: preserve ipv6 probe and startup upload semantics

### DIFF
--- a/src/basic_info_flow.zig
+++ b/src/basic_info_flow.zig
@@ -8,6 +8,7 @@ pub const UploadContext = enum {
 
 pub const ForegroundUploadOutcome = union(enum) {
     success,
+    deferred,
     failure: anyerror,
 };
 
@@ -24,6 +25,10 @@ pub fn handleForegroundUploadResult(
     result: anyerror!void,
 ) !ForegroundUploadOutcome {
     result catch |err| {
+        if (err == error.BasicInfoDeferredUntilPublicIp) {
+            try writer.print("Basic info upload deferred during {s}: waiting for public IP refresh\n", .{contextLabel(context)});
+            return .deferred;
+        }
         try writer.print("Basic info upload failed during {s}: {s}\n", .{ contextLabel(context), @errorName(err) });
         return .{ .failure = err };
     };

--- a/src/basic_info_flow.zig
+++ b/src/basic_info_flow.zig
@@ -12,6 +12,10 @@ pub const ForegroundUploadOutcome = union(enum) {
     failure: anyerror,
 };
 
+pub fn shouldStartBackgroundLoopImmediately(outcome: ForegroundUploadOutcome) bool {
+    return outcome == .deferred;
+}
+
 pub fn contextLabel(context: UploadContext) []const u8 {
     return switch (context) {
         .startup => "startup",

--- a/src/main.zig
+++ b/src/main.zig
@@ -202,6 +202,10 @@ fn uploadBasicInfoOnce(allocator: std.mem.Allocator, cfg: config.Config, allow_e
     var info = try provider.basicInfo(scratch);
     debug.log("basic info collected: local_ipv4={s} local_ipv6={s}", .{ info.ipv4, info.ipv6 });
     try applyIpConfig(scratch, cfg, &info, allow_external_ip_lookup);
+    if (!allow_external_ip_lookup and info.ipv4.len == 0) {
+        debug.log("deferring foreground basic info upload until public IP refresh because IPv4 is empty", .{});
+        return error.BasicInfoDeferredUntilPublicIp;
+    }
     const info_json = try basic_info.allocBasicInfoJson(scratch, info, true);
     try stdout.print("Basic info ready: {d} bytes\n", .{info_json.len});
     debug.log("basic info prepared: upload_bytes={d} final_ipv4={s} final_ipv6={s}", .{ info_json.len, info.ipv4, info.ipv6 });
@@ -221,6 +225,7 @@ fn runForegroundBasicInfoUpload(
     const outcome = try basic_info_flow.handleForegroundUploadResult(&stdout, context, uploadBasicInfoOnce(allocator, cfg, allow_external_ip_lookup));
     switch (outcome) {
         .success => debug.log("basic info upload finished successfully during {s}", .{basic_info_flow.contextLabel(context)}),
+        .deferred => debug.log("basic info upload deferred during {s}", .{basic_info_flow.contextLabel(context)}),
         .failure => |err| debug.log("basic info upload failed during {s}: {s}", .{ basic_info_flow.contextLabel(context), @errorName(err) }),
     }
 }
@@ -233,15 +238,18 @@ fn startBasicInfoLoop(allocator: std.mem.Allocator, cfg: config.Config) void {
 fn basicInfoLoop(allocator: std.mem.Allocator, cfg: config.Config) void {
     const mins: u64 = if (cfg.info_report_interval <= 0) 5 else @intCast(cfg.info_report_interval);
     while (true) {
-        compat.sleep(mins * 60 * std.time.ns_per_s);
         var arena = std.heap.ArenaAllocator.init(allocator);
         defer arena.deinit();
         const scratch = arena.allocator();
-        var info = provider.basicInfo(scratch) catch continue;
+        var info = provider.basicInfo(scratch) catch {
+            compat.sleep(mins * 60 * std.time.ns_per_s);
+            continue;
+        };
         applyIpConfig(scratch, cfg, &info, true) catch {};
         basic_info.upload(scratch, cfg, info) catch |err| {
             debug.log("background basic info upload failed: {s}", .{@errorName(err)});
         };
+        compat.sleep(mins * 60 * std.time.ns_per_s);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -113,9 +113,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     printMonitoringLists(allocator, cfg) catch {};
 
     if (shutdown_requested.load(.acquire)) return;
-    try runForegroundBasicInfoUpload(allocator, cfg, false, .startup);
+    const startup_outcome = try runForegroundBasicInfoUpload(allocator, cfg, false, .startup);
     if (shutdown_requested.load(.acquire)) return;
-    startBasicInfoLoop(allocator, cfg);
+    startBasicInfoLoop(allocator, cfg, basic_info_flow.shouldStartBackgroundLoopImmediately(startup_outcome));
 
     if (shutdown_requested.load(.acquire)) return;
 
@@ -124,7 +124,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
             try stdout.print("Report websocket exited: {s}\n", .{@errorName(err)});
         };
         if (shutdown_requested.load(.acquire)) break;
-        try runForegroundBasicInfoUpload(allocator, cfg, false, .websocket_reconnect);
+        _ = try runForegroundBasicInfoUpload(allocator, cfg, false, .websocket_reconnect);
     }
     try stdout.writeAll("shutting down gracefully...\n");
 }
@@ -217,7 +217,7 @@ fn runForegroundBasicInfoUpload(
     cfg: config.Config,
     allow_external_ip_lookup: bool,
     context: basic_info_flow.UploadContext,
-) !void {
+) !basic_info_flow.ForegroundUploadOutcome {
     var stdout_buf: [4096]u8 = undefined;
     var stdout = compat.fileWriter(std.Io.File.stdout(), &stdout_buf);
     defer stdout.flush() catch {};
@@ -228,28 +228,32 @@ fn runForegroundBasicInfoUpload(
         .deferred => debug.log("basic info upload deferred during {s}", .{basic_info_flow.contextLabel(context)}),
         .failure => |err| debug.log("basic info upload failed during {s}: {s}", .{ basic_info_flow.contextLabel(context), @errorName(err) }),
     }
+    return outcome;
 }
 
-fn startBasicInfoLoop(allocator: std.mem.Allocator, cfg: config.Config) void {
-    const thread = std.Thread.spawn(.{ .stack_size = thread_stacks.tls_worker_stack_size }, basicInfoLoop, .{ allocator, cfg }) catch return;
+fn startBasicInfoLoop(allocator: std.mem.Allocator, cfg: config.Config, start_immediately: bool) void {
+    const thread = std.Thread.spawn(.{ .stack_size = thread_stacks.tls_worker_stack_size }, basicInfoLoop, .{ allocator, cfg, start_immediately }) catch return;
     thread.detach();
 }
 
-fn basicInfoLoop(allocator: std.mem.Allocator, cfg: config.Config) void {
+fn basicInfoLoop(allocator: std.mem.Allocator, cfg: config.Config, start_immediately: bool) void {
     const mins: u64 = if (cfg.info_report_interval <= 0) 5 else @intCast(cfg.info_report_interval);
+    var first = true;
     while (true) {
+        if (!start_immediately or !first) {
+            compat.sleep(mins * 60 * std.time.ns_per_s);
+        }
+        first = false;
         var arena = std.heap.ArenaAllocator.init(allocator);
         defer arena.deinit();
         const scratch = arena.allocator();
         var info = provider.basicInfo(scratch) catch {
-            compat.sleep(mins * 60 * std.time.ns_per_s);
             continue;
         };
         applyIpConfig(scratch, cfg, &info, true) catch {};
         basic_info.upload(scratch, cfg, info) catch |err| {
             debug.log("background basic info upload failed: {s}", .{@errorName(err)});
         };
-        compat.sleep(mins * 60 * std.time.ns_per_s);
     }
 }
 

--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -660,8 +660,9 @@ fn parseMiB(value: []const u8) u64 {
 }
 
 fn commandOutputFirstLine(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
-    try ensureExecutable(allocator, argv[0]);
-    const result = try compat.runOutputIgnoreStderr(allocator, argv, null, 64 * 1024);
+    const resolved_argv = try resolveExecutableArgv(allocator, argv);
+    defer freeResolvedArgv(allocator, resolved_argv, argv);
+    const result = try compat.runOutputIgnoreStderr(allocator, resolved_argv, null, 64 * 1024);
     defer allocator.free(result.stdout);
     if (result.term != .exited or result.term.exited != 0) return error.CommandFailed;
     var it = std.mem.splitScalar(u8, result.stdout, '\n');
@@ -810,10 +811,7 @@ fn routeSourceAddress(
 }
 
 pub fn canProbeIpv6(allocator: std.mem.Allocator, include_nics: []const u8, exclude_nics: []const u8) !bool {
-    const output = commandOutput(allocator, &.{ "ip", "-6", "route", "get", "2001:4860:4860::8888" }) catch |err| {
-        debug.log("ipv6 probe route check failed: {s}", .{@errorName(err)});
-        return false;
-    };
+    const output = try commandOutput(allocator, &.{ "ip", "-6", "route", "get", "2001:4860:4860::8888" });
     defer allocator.free(output);
     const probeable = canProbeRoute(output, include_nics, exclude_nics, .ipv6);
     if (!probeable) {
@@ -823,30 +821,48 @@ pub fn canProbeIpv6(allocator: std.mem.Allocator, include_nics: []const u8, excl
 }
 
 fn commandOutput(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
-    try ensureExecutable(allocator, argv[0]);
+    const resolved_argv = try resolveExecutableArgv(allocator, argv);
+    defer freeResolvedArgv(allocator, resolved_argv, argv);
     var env = compat.emptyEnvMap(allocator);
     defer env.deinit();
     try env.put("PATH", safe_command_path);
-    const result = try compat.runOutputIgnoreStderr(allocator, argv, &env, 256 * 1024);
+    const result = try compat.runOutputIgnoreStderr(allocator, resolved_argv, &env, 256 * 1024);
     errdefer allocator.free(result.stdout);
     if (result.term != .exited or result.term.exited != 0) return error.CommandFailed;
     return result.stdout;
 }
 
-fn ensureExecutable(allocator: std.mem.Allocator, exe: []const u8) !void {
+fn resolveExecutableArgv(allocator: std.mem.Allocator, argv: []const []const u8) ![]const []const u8 {
+    if (argv.len == 0) return error.InvalidArgs;
+    const resolved_exe = try resolveExecutable(allocator, argv[0]);
+    errdefer if (resolved_exe.ptr != argv[0].ptr) allocator.free(resolved_exe);
+    const resolved = try allocator.dupe([]const u8, argv);
+    resolved[0] = resolved_exe;
+    return resolved;
+}
+
+fn freeResolvedArgv(allocator: std.mem.Allocator, resolved: []const []const u8, original: []const []const u8) void {
+    if (resolved.len != 0 and original.len != 0 and resolved[0].ptr != original[0].ptr) allocator.free(resolved[0]);
+    allocator.free(resolved);
+}
+
+pub fn resolveExecutable(allocator: std.mem.Allocator, exe: []const u8) ![]const u8 {
     if (std.mem.indexOfScalar(u8, exe, '/')) |_| {
         const stat = compat.statFile(exe) catch return error.FileNotFound;
         if (stat.kind != .file) return error.FileNotFound;
-        return;
+        return exe;
     }
 
     var dirs = std.mem.splitScalar(u8, safe_command_path, ':');
     while (dirs.next()) |dir| {
         if (dir.len == 0) continue;
         const full = try std.fs.path.join(allocator, &.{ dir, exe });
-        defer allocator.free(full);
-        const stat = compat.statFile(full) catch continue;
-        if (stat.kind == .file) return;
+        const stat = compat.statFile(full) catch {
+            allocator.free(full);
+            continue;
+        };
+        if (stat.kind == .file) return full;
+        allocator.free(full);
     }
     return error.FileNotFound;
 }

--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -811,7 +811,10 @@ fn routeSourceAddress(
 }
 
 pub fn canProbeIpv6(allocator: std.mem.Allocator, include_nics: []const u8, exclude_nics: []const u8) !bool {
-    const output = try commandOutput(allocator, &.{ "ip", "-6", "route", "get", "2001:4860:4860::8888" });
+    const output = commandOutput(allocator, &.{ "ip", "-6", "route", "get", "2001:4860:4860::8888" }) catch |err| {
+        debug.log("ipv6 probe route check failed: {s}", .{@errorName(err)});
+        return false;
+    };
     defer allocator.free(output);
     const probeable = canProbeRoute(output, include_nics, exclude_nics, .ipv6);
     if (!probeable) {

--- a/src/platform/provider.zig
+++ b/src/platform/provider.zig
@@ -49,7 +49,7 @@ pub fn localIpFromInterfaces(allocator: std.mem.Allocator, include_nics: []const
 }
 
 pub fn canProbeIpv6(allocator: std.mem.Allocator, include_nics: []const u8, exclude_nics: []const u8) bool {
-    if (@hasDecl(impl, "canProbeIpv6")) return impl.canProbeIpv6(allocator, include_nics, exclude_nics) catch true;
+    if (@hasDecl(impl, "canProbeIpv6")) return impl.canProbeIpv6(allocator, include_nics, exclude_nics) catch false;
     return true;
 }
 

--- a/test/basic_info_flow_test.zig
+++ b/test/basic_info_flow_test.zig
@@ -8,10 +8,23 @@ test "foreground upload success keeps success log" {
     const outcome = try flow.handleForegroundUploadResult(&out.writer, .startup, {});
     switch (outcome) {
         .success => {},
-        .failure => return error.TestUnexpectedResult,
+        .deferred, .failure => return error.TestUnexpectedResult,
     }
 
     try std.testing.expectEqualStrings("Basic info uploaded successfully\n", out.written());
+}
+
+test "foreground upload deferral is reported without failure" {
+    var out = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer out.deinit();
+
+    const outcome = try flow.handleForegroundUploadResult(&out.writer, .startup, error.BasicInfoDeferredUntilPublicIp);
+    switch (outcome) {
+        .deferred => {},
+        .success, .failure => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expectEqualStrings("Basic info upload deferred during startup: waiting for public IP refresh\n", out.written());
 }
 
 test "foreground upload failure during startup is tolerated and logged" {
@@ -20,7 +33,7 @@ test "foreground upload failure during startup is tolerated and logged" {
 
     const outcome = try flow.handleForegroundUploadResult(&out.writer, .startup, error.Timeout);
     switch (outcome) {
-        .success => return error.TestUnexpectedResult,
+        .success, .deferred => return error.TestUnexpectedResult,
         .failure => |err| try std.testing.expectEqual(error.Timeout, err),
     }
 
@@ -33,7 +46,7 @@ test "foreground upload failure during websocket reconnect is tolerated and logg
 
     const outcome = try flow.handleForegroundUploadResult(&out.writer, .websocket_reconnect, error.HttpStatusNotOk);
     switch (outcome) {
-        .success => return error.TestUnexpectedResult,
+        .success, .deferred => return error.TestUnexpectedResult,
         .failure => |err| try std.testing.expectEqual(error.HttpStatusNotOk, err),
     }
 

--- a/test/basic_info_flow_test.zig
+++ b/test/basic_info_flow_test.zig
@@ -27,6 +27,12 @@ test "foreground upload deferral is reported without failure" {
     try std.testing.expectEqualStrings("Basic info upload deferred during startup: waiting for public IP refresh\n", out.written());
 }
 
+test "foreground upload deferral is the only case that restarts background loop immediately" {
+    try std.testing.expect(!flow.shouldStartBackgroundLoopImmediately(.success));
+    try std.testing.expect(flow.shouldStartBackgroundLoopImmediately(.deferred));
+    try std.testing.expect(!flow.shouldStartBackgroundLoopImmediately(.{ .failure = error.Timeout }));
+}
+
 test "foreground upload failure during startup is tolerated and logged" {
     var out = std.Io.Writer.Allocating.init(std.testing.allocator);
     defer out.deinit();

--- a/test/network_filter_test.zig
+++ b/test/network_filter_test.zig
@@ -85,12 +85,22 @@ test "ip route parser extracts IPv6 source from multiline route output" {
     const ipv6 = linux.parseIpRouteGetSource(
         \\2001:4860:4860::8888 from :: via fe80::1 dev ens3 proto ra metric 100 pref medium
         \\    cache from :: src 2001:db8::10 metric 100 pref medium
-        ,
+    ,
         "",
         "",
         .ipv6,
     ) orelse "";
     try std.testing.expectEqualStrings("2001:db8::10", ipv6);
+}
+
+test "ip route parser extracts IPv6 source from RA route output" {
+    const ipv6 = linux.parseIpRouteGetSource(
+        "2001:4860:4860::8888 from :: via fe80::1 dev ens3 proto ra src 2001:db8::20 metric 1024 pref medium",
+        "",
+        "",
+        .ipv6,
+    ) orelse "";
+    try std.testing.expectEqualStrings("2001:db8::20", ipv6);
 }
 
 test "ipv6 probe route accepts allowed interface without explicit source" {


### PR DESCRIPTION
Fix issue #11 by preserving the IPv6 probe route semantics and limiting immediate background basic-info retries to deferred startup uploads only.\n\nValidated with local zig build and zig build test.