### PR TITLE
Sync upstream v2 protocol compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,7 @@ jobs:
           set -eu
           sudo sysctl -w net.ipv4.ping_group_range='0 2147483647' >/dev/null
           python3 -m py_compile scripts/mock_komari_business_e2e.py
+          python3 -m py_compile scripts/mock_komari_v2_e2e.py
           python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --cf --no-exec
           python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent
           python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --terminal --no-exec
@@ -196,6 +197,9 @@ jobs:
           python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --proxy --no-exec
           python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --custom-dns --no-exec
           python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --no-exec --sudo-agent --tcp-ping-count 10 --http-ping-count 2 --icmp-ping-count 2
+          python3 scripts/mock_komari_v2_e2e.py ws zig-out/bin/komari-agent --terminal
+          python3 scripts/mock_komari_v2_e2e.py post-fallback zig-out/bin/komari-agent
+          python3 scripts/mock_komari_v2_e2e.py post-recover zig-out/bin/komari-agent
       - name: Run self-update E2E
         run: |
           set -eu

--- a/basic_info_v2_test.zig
+++ b/basic_info_v2_test.zig
@@ -1,0 +1,230 @@
+const std = @import("std");
+const basic_info = @import("src/protocol/basic_info.zig");
+const config = @import("src/config.zig");
+const local_http = @import("test/local_http.zig");
+
+test "basic info v2 upload sends rpc request and accepts response" {
+    const body = "{\"jsonrpc\":\"2.0\",\"result\":{\"status\":\"ok\"}}";
+    const response = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ body.len, body },
+    );
+    const responses = [_][]const u8{response};
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+
+    basic_info.initRequestedProtocolVersionForTest(2);
+    basic_info.resetConnectionProtocolVersionForTest();
+    defer basic_info.resetConnectionProtocolVersionForTest();
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+    try basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true);
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), completed.requests.len);
+    const request = completed.requests[0];
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", request.requestLine());
+    try std.testing.expectEqualStrings("komari-zig-agent", request.header("User-Agent").?);
+    try std.testing.expectEqualStrings("application/json", request.header("Content-Type").?);
+    try std.testing.expect(request.header("Content-Encoding") == null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, request.body, .{});
+    defer parsed.deinit();
+    const root = try expectObject(parsed.value);
+    try expectStringField(root, "jsonrpc", "2.0");
+    try expectStringField(root, "method", "agent.basicInfo");
+}
+
+test "basic info v2 upload gzips body by default" {
+    const body = "{\"jsonrpc\":\"2.0\",\"result\":{\"status\":\"ok\"}}";
+    const response = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ body.len, body },
+    );
+    const responses = [_][]const u8{response};
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+    errdefer server.join() catch unreachable;
+
+    basic_info.initRequestedProtocolVersionForTest(2);
+    basic_info.resetConnectionProtocolVersionForTest();
+    defer basic_info.resetConnectionProtocolVersionForTest();
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .max_retries = 0,
+    };
+    try basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true);
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), completed.requests.len);
+    const request = completed.requests[0];
+    try std.testing.expectEqualStrings("gzip", request.header("Content-Encoding").?);
+
+    const decoded = try decompressGzip(std.testing.allocator, request.body);
+    defer std.testing.allocator.free(decoded);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, decoded, .{});
+    defer parsed.deinit();
+    const root = try expectObject(parsed.value);
+    try expectStringField(root, "jsonrpc", "2.0");
+    try expectStringField(root, "method", "agent.basicInfo");
+}
+
+test "basic info v2 rejects rpc error responses" {
+    const body = "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"boom\"}}";
+    const response = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ body.len, body },
+    );
+    const responses = [_][]const u8{response};
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+    defer server.join() catch unreachable;
+
+    basic_info.initRequestedProtocolVersionForTest(2);
+    basic_info.resetConnectionProtocolVersionForTest();
+    defer basic_info.resetConnectionProtocolVersionForTest();
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+    try std.testing.expectError(error.InvalidV2Response, basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true));
+}
+
+test "basic info v2 falls back to v1 after three transport failures" {
+    const responses = [_][]const u8{
+        "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    };
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+
+    basic_info.initRequestedProtocolVersionForTest(2);
+    basic_info.resetConnectionProtocolVersionForTest();
+    defer basic_info.resetConnectionProtocolVersionForTest();
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+
+    try std.testing.expectError(error.HttpStatusNotOk, basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true));
+    try std.testing.expectError(error.HttpStatusNotOk, basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true));
+    try basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true);
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 4), completed.requests.len);
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[0].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[1].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[2].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/uploadBasicInfo?token=tok HTTP/1.1", completed.requests[3].requestLine());
+    try std.testing.expectEqual(@as(i32, 1), basic_info.uploadProtocolVersionForTest());
+}
+
+test "basic info v2 falls back to v1 after three invalid rpc responses" {
+    const invalid_body = "{\"jsonrpc\":\"1.0\"}";
+    const invalid_response = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ invalid_body.len, invalid_body },
+    );
+    const responses = [_][]const u8{
+        invalid_response,
+        invalid_response,
+        invalid_response,
+        "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    };
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+    errdefer server.join() catch unreachable;
+
+    basic_info.initRequestedProtocolVersionForTest(2);
+    basic_info.resetConnectionProtocolVersionForTest();
+    defer basic_info.resetConnectionProtocolVersionForTest();
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+
+    try std.testing.expectError(error.InvalidV2Response, basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true));
+    try std.testing.expectError(error.InvalidV2Response, basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true));
+    try basic_info.uploadV2(std.testing.allocator, cfg, sampleBasicInfo(), true);
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 4), completed.requests.len);
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[0].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[1].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[2].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/uploadBasicInfo?token=tok HTTP/1.1", completed.requests[3].requestLine());
+    try std.testing.expectEqual(@as(i32, 1), basic_info.uploadProtocolVersionForTest());
+}
+
+fn sampleBasicInfo() basic_info.BasicInfo {
+    return .{
+        .cpu = .{
+            .name = "CPU",
+            .architecture = "amd64",
+            .cores = 8,
+            .physical_cores = 4,
+        },
+        .os_name = "linux",
+        .kernel_version = "6.1.0",
+        .ipv4 = "192.0.2.1",
+        .ipv6 = "2001:db8::1",
+        .mem_total = 1024,
+        .swap_total = 2048,
+        .disk_total = 4096,
+        .gpu_name = "GPU",
+        .virtualization = "kvm",
+    };
+}
+
+fn expectObject(value: std.json.Value) !std.json.ObjectMap {
+    if (value != .object) return error.TestUnexpectedResult;
+    return value.object;
+}
+
+fn expectStringField(object: std.json.ObjectMap, key: []const u8, expected: []const u8) !void {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    if (value != .string) return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(expected, value.string);
+}
+
+fn decompressGzip(allocator: std.mem.Allocator, compressed: []const u8) ![]u8 {
+    var reader: std.Io.Reader = .fixed(compressed);
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    var history: [std.compress.flate.max_window_len]u8 = undefined;
+    var decompress: std.compress.flate.Decompress = .init(&reader, .gzip, history[0..]);
+    _ = try decompress.reader.streamRemaining(&out.writer);
+    return try out.toOwnedSlice();
+}

--- a/build.zig
+++ b/build.zig
@@ -142,6 +142,7 @@ pub fn build(b: *std.Build) void {
         "test/coverage_test.zig",
         "src/terminal_test.zig",
         "test/ws_message_test.zig",
+        "test/v2_state_test.zig",
         "test/ws_client_test.zig",
         "test/raw_conn_test.zig",
         "test/thread_stack_test.zig",
@@ -152,6 +153,8 @@ pub fn build(b: *std.Build) void {
     for (test_paths) |test_path| {
         addTest(b, test_step, test_path, target, optimize, opts, version_module, compat_module, net_module, debug_module, coverage, coverage_dir);
     }
+    addStandaloneV2Test(b, test_step, "basic_info_v2_test.zig", target, optimize, opts, compat_module, net_module, debug_module, zigpty_module);
+    addStandaloneV2Test(b, test_step, "report_ws_v2_test.zig", target, optimize, opts, compat_module, net_module, debug_module, zigpty_module);
 }
 
 fn addCompatImports(module: *std.Build.Module, compat_module: *std.Build.Module, net_module: *std.Build.Module) void {
@@ -283,6 +286,9 @@ fn addTest(
         .optimize = optimize,
     });
     addCompatImports(protocol_task, compat_module, net_module);
+    protocol_task.addImport("debug", debug_module);
+    protocol_task.addImport("idna", idna_module);
+    protocol_task.addImport("dns", dns_module);
     tests.root_module.addImport("protocol_task", protocol_task);
     const protocol_ping = b.createModule(.{
         .root_source_file = b.path("src/protocol/ping.zig"),
@@ -305,6 +311,11 @@ fn addTest(
     tests.root_module.addImport("protocol_ip", protocol_ip);
     tests.root_module.addImport("protocol_ws_message", b.createModule(.{
         .root_source_file = b.path("src/protocol/ws_message.zig"),
+        .target = target,
+        .optimize = optimize,
+    }));
+    tests.root_module.addImport("protocol_v2_state", b.createModule(.{
+        .root_source_file = b.path("src/protocol/v2_state.zig"),
         .target = target,
         .optimize = optimize,
     }));
@@ -343,6 +354,58 @@ fn addTest(
         run_tests.step.dependOn(&make_coverage_dir.step);
         test_step.dependOn(&run_tests.step);
         return;
+    }
+
+    const run_tests = b.addRunArtifact(tests);
+    test_step.dependOn(&run_tests.step);
+}
+
+fn addStandaloneV2Test(
+    b: *std.Build,
+    test_step: *std.Build.Step,
+    path: []const u8,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    opts: *std.Build.Step.Options,
+    compat_module: *std.Build.Module,
+    net_module: *std.Build.Module,
+    debug_module: *std.Build.Module,
+    zigpty_module: ?*std.Build.Module,
+) void {
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path(path),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    tests.root_module.addOptions("build_options", opts);
+    addCompatImports(tests.root_module, compat_module, net_module);
+    tests.root_module.addImport("debug", debug_module);
+    const idna_module = b.createModule(.{
+        .root_source_file = b.path("src/idna.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const dns_module = b.createModule(.{
+        .root_source_file = b.path("src/dns.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    addCompatImports(dns_module, compat_module, net_module);
+    tests.root_module.addImport("idna", idna_module);
+    tests.root_module.addImport("dns", dns_module);
+    const report_netstatic = b.createModule(.{
+        .root_source_file = b.path("src/report/netstatic.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    addCompatImports(report_netstatic, compat_module, net_module);
+    tests.root_module.addImport("report_netstatic", report_netstatic);
+    if (zigpty_module) |mod| tests.root_module.addImport("zigpty", mod);
+    if (target.result.os.tag == .windows) {
+        tests.root_module.linkSystemLibrary("advapi32", .{});
+        tests.root_module.linkSystemLibrary("iphlpapi", .{});
     }
 
     const run_tests = b.addRunArtifact(tests);

--- a/report_ws_v2_test.zig
+++ b/report_ws_v2_test.zig
@@ -1,0 +1,165 @@
+const std = @import("std");
+const config = @import("src/config.zig");
+const local_http = @import("test/local_http.zig");
+const report_ws = @import("src/protocol/report_ws.zig");
+
+test "v2 pull request sends ack ids and clears them after success" {
+    const first_body = "{\"jsonrpc\":\"2.0\",\"result\":{\"events\":[{\"id\":\"ev-1\",\"method\":\"agent.message\",\"params\":{\"text\":\"hello\"}}]}}";
+    const second_body = "{\"jsonrpc\":\"2.0\",\"result\":{\"events\":[{\"id\":\"ev-1\",\"method\":\"agent.message\",\"params\":{\"text\":\"hello\"}},{\"id\":\"ev-2\",\"method\":\"agent.event\",\"params\":{}}],\"status\":\"ok\"}}";
+    const third_body = "{\"jsonrpc\":\"2.0\",\"result\":{\"events\":[],\"status\":\"ok\"}}";
+    const responses = [_][]const u8{
+        std.fmt.comptimePrint("HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{ first_body.len, first_body }),
+        std.fmt.comptimePrint("HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{ second_body.len, second_body }),
+        std.fmt.comptimePrint("HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}", .{ third_body.len, third_body }),
+    };
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+
+    report_ws.initRequestedProtocolVersionForTest(2);
+    report_ws.resetConnectionProtocolVersionForTest();
+    defer report_ws.resetConnectionProtocolVersionForTest();
+    report_ws.resetV2ResponseTrackingForTest();
+    defer report_ws.resetV2ResponseTrackingForTest();
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+    try report_ws.postV2PullOnceForTest(std.testing.allocator, cfg);
+    try report_ws.postV2PullOnceForTest(std.testing.allocator, cfg);
+    try report_ws.postV2PullOnceForTest(std.testing.allocator, cfg);
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), completed.requests.len);
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[0].requestLine());
+    var parsed_first = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, completed.requests[0].body, .{});
+    defer parsed_first.deinit();
+    const first_root = try expectObject(parsed_first.value);
+    const first_params = try expectObjectValue(first_root, "params");
+    const first_ack_ids = try expectArrayValue(first_params, "ack_event_ids");
+    try std.testing.expectEqual(@as(usize, 0), first_ack_ids.items.len);
+
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[1].requestLine());
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[2].requestLine());
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, completed.requests[1].body, .{});
+    defer parsed.deinit();
+    const root = try expectObject(parsed.value);
+    const params = try expectObjectValue(root, "params");
+    const ack_ids = try expectArrayValue(params, "ack_event_ids");
+    try std.testing.expectEqual(@as(usize, 1), ack_ids.items.len);
+    try std.testing.expectEqualStrings("ev-1", ack_ids.items[0].string);
+
+    var parsed_third = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, completed.requests[2].body, .{});
+    defer parsed_third.deinit();
+    const third_root = try expectObject(parsed_third.value);
+    const third_params = try expectObjectValue(third_root, "params");
+    const third_ack_ids = try expectArrayValue(third_params, "ack_event_ids");
+    try std.testing.expectEqual(@as(usize, 2), third_ack_ids.items.len);
+    try std.testing.expectEqualStrings("ev-1", third_ack_ids.items[0].string);
+    try std.testing.expectEqualStrings("ev-2", third_ack_ids.items[1].string);
+
+    const snapshot = try report_ws.snapshotV2AckEventIDsForTest(std.testing.allocator);
+    defer std.testing.allocator.free(snapshot);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.len);
+}
+
+test "v2 response rejects invalid jsonrpc payloads" {
+    report_ws.resetV2ResponseTrackingForTest();
+    defer report_ws.resetV2ResponseTrackingForTest();
+    report_ws.initRequestedProtocolVersionForTest(2);
+    report_ws.resetConnectionProtocolVersionForTest();
+    defer report_ws.resetConnectionProtocolVersionForTest();
+
+    const cfg = config.Config{
+        .endpoint = "http://127.0.0.1:1",
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+    try std.testing.expectError(error.InvalidV2Response, report_ws.processV2ResponseBodyForTest(std.testing.allocator, cfg, "{\"jsonrpc\":\"1.0\"}"));
+}
+
+test "v2 report helper includes ack ids and clears them after success" {
+    const seed_cfg = config.Config{
+        .endpoint = "http://127.0.0.1:1",
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+    const response_body = "{\"jsonrpc\":\"2.0\",\"result\":{\"status\":\"ok\"}}";
+    const response = std.fmt.comptimePrint(
+        "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ response_body.len, response_body },
+    );
+    const responses = [_][]const u8{response};
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+    errdefer server.join() catch unreachable;
+
+    report_ws.resetV2ResponseTrackingForTest();
+    defer report_ws.resetV2ResponseTrackingForTest();
+    try report_ws.processV2ResponseBodyForTest(
+        std.testing.allocator,
+        seed_cfg,
+        "{\"jsonrpc\":\"2.0\",\"result\":{\"events\":[{\"id\":\"ev-report-1\",\"method\":\"agent.message\",\"params\":{\"text\":\"hello\"}}],\"status\":\"ok\"}}",
+    );
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .max_retries = 0,
+    };
+    try report_ws.postV2ReportPayloadForTest(std.testing.allocator, cfg, "{\"counter\":1}");
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), completed.requests.len);
+    try std.testing.expectEqualStrings("POST /api/clients/v2/rpc?token=tok HTTP/1.1", completed.requests[0].requestLine());
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, completed.requests[0].body, .{});
+    defer parsed.deinit();
+    const root = try expectObject(parsed.value);
+    try expectStringField(root, "jsonrpc", "2.0");
+    try expectStringField(root, "method", "agent.report");
+    const params = try expectObjectValue(root, "params");
+    const report_value = try expectObjectValue(params, "report");
+    const counter = report_value.get("counter") orelse return error.TestUnexpectedResult;
+    if (counter != .integer) return error.TestUnexpectedResult;
+    try std.testing.expectEqual(@as(i64, 1), counter.integer);
+    const ack_ids = try expectArrayValue(params, "ack_event_ids");
+    try std.testing.expectEqual(@as(usize, 1), ack_ids.items.len);
+    try std.testing.expectEqualStrings("ev-report-1", ack_ids.items[0].string);
+
+    const snapshot = try report_ws.snapshotV2AckEventIDsForTest(std.testing.allocator);
+    defer std.testing.allocator.free(snapshot);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.len);
+}
+
+fn expectObject(value: std.json.Value) !std.json.ObjectMap {
+    if (value != .object) return error.TestUnexpectedResult;
+    return value.object;
+}
+
+fn expectStringField(object: std.json.ObjectMap, key: []const u8, expected: []const u8) !void {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    if (value != .string) return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(expected, value.string);
+}
+
+fn expectObjectValue(object: std.json.ObjectMap, key: []const u8) !std.json.ObjectMap {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    return expectObject(value);
+}
+
+fn expectArrayValue(object: std.json.ObjectMap, key: []const u8) !std.json.Array {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    if (value != .array) return error.TestUnexpectedResult;
+    return value.array;
+}

--- a/scripts/mock_komari_business_e2e.py
+++ b/scripts/mock_komari_business_e2e.py
@@ -499,6 +499,7 @@ def run_panel_e2e(args):
         cmd += ["--token", TOKEN]
     cmd += [
         "--disable-auto-update",
+        "--protocol-version", str(args.protocol_version),
         "--max-retries", "0",
         "--reconnect-interval", "1",
         "--info-report-interval", "60",
@@ -600,11 +601,11 @@ def run_self_update_e2e(args):
         try:
             first = subprocess.run([
                 old_path, "--endpoint", f"http://127.0.0.1:{server.server_address[1]}",
-                "--token", TOKEN, "--show-warning=false",
+                "--token", TOKEN, "--protocol-version", str(args.protocol_version), "--show-warning=false",
             ], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=20)
             if first.returncode != 42:
                 raise RuntimeError(f"update did not exit 42: {first.returncode}\n{first.stdout}")
-            second = subprocess.run([old_path, "--show-warning"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10)
+            second = subprocess.run([old_path, "--protocol-version", str(args.protocol_version), "--show-warning"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10)
             if second.returncode != 0:
                 raise RuntimeError(f"updated binary preflight failed: {second.returncode}\n{second.stdout}")
             tcp = TcpAcceptServer(("127.0.0.1", 0), TcpAcceptHandler)
@@ -621,10 +622,13 @@ def run_self_update_e2e(args):
                 old_path,
                 "--endpoint", f"http://127.0.0.1:{panel.server_address[1]}",
                 "--token", TOKEN,
+                "--protocol-version", str(args.protocol_version),
                 "--disable-auto-update",
                 "--max-retries", "0",
                 "--reconnect-interval", "1",
                 "--info-report-interval", "60",
+                "--custom-ipv4", "203.0.113.10",
+                "--custom-ipv6", "2001:db8::10",
             ], os.environ.copy(), 20, output)
             try:
                 while time.monotonic() < deadline:
@@ -645,18 +649,12 @@ def run_self_update_e2e(args):
                 tcp.server_close()
             if os.path.exists(old_path + ".bak") or os.path.exists(old_path + ".update-state.json"):
                 raise RuntimeError("pending update files were not confirmed and cleaned")
-            version_output = []
-            version_proc, version_deadline = run_agent([
+            version = subprocess.run([
                 old_path,
-                "--endpoint", "http://127.0.0.1:9",
-                "--token", TOKEN,
                 "--disable-auto-update",
-                "--max-retries", "0",
-            ], os.environ.copy(), 10, version_output)
-            try:
-                wait_for_output_contains(version_proc, version_output, "Komari Agent v9.9.9", version_deadline)
-            finally:
-                terminate(version_proc)
+            ], env=os.environ.copy(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10)
+            if version.returncode != 0 or "Komari Agent v9.9.9" not in version.stdout:
+                raise RuntimeError(f"updated binary version check failed: {version.returncode}\n{version.stdout}")
 
             rollback_path = os.path.join(tmp, "komari-agent-rollback")
             shutil.copy2(args.new_agent, rollback_path)
@@ -669,6 +667,7 @@ def run_self_update_e2e(args):
                 rollback_path,
                 "--endpoint", f"http://127.0.0.1:{server.server_address[1]}",
                 "--token", TOKEN,
+                "--protocol-version", str(args.protocol_version),
                 "--disable-auto-update",
                 "--max-retries", "0",
             ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=10)
@@ -689,6 +688,7 @@ def main():
     sub = parser.add_subparsers(dest="mode", required=True)
     panel = sub.add_parser("panel")
     panel.add_argument("agent")
+    panel.add_argument("--protocol-version", type=int, default=1)
     panel.add_argument("--timeout", type=float, default=35)
     panel.add_argument("--no-exec", action="store_true")
     panel.add_argument("--terminal", action="store_true")
@@ -703,6 +703,7 @@ def main():
     update = sub.add_parser("self-update")
     update.add_argument("--old-agent", required=True)
     update.add_argument("--new-agent", required=True)
+    update.add_argument("--protocol-version", type=int, default=1)
     args = parser.parse_args()
     if args.mode == "panel":
         return run_panel_e2e(args)

--- a/scripts/mock_komari_smoke.py
+++ b/scripts/mock_komari_smoke.py
@@ -250,6 +250,7 @@ def drain_output(pipe, lines):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("agent")
+    parser.add_argument("--protocol-version", type=int, default=1)
     parser.add_argument("--max-basic-info-seconds", type=float, default=15.0)
     parser.add_argument("--max-e2e-seconds", type=float, default=25.0)
     args = parser.parse_args()
@@ -269,6 +270,8 @@ def main():
         token,
         "--disable-auto-update",
         "--disable-web-ssh",
+        "--protocol-version",
+        str(args.protocol_version),
         "--max-retries",
         "0",
         "--reconnect-interval",

--- a/scripts/mock_komari_v2_e2e.py
+++ b/scripts/mock_komari_v2_e2e.py
@@ -1,0 +1,930 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import hashlib
+import json
+import os
+import socket
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+
+class TcpAcceptServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+class TcpAcceptHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        return
+
+
+class QuietThreadingHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def handle_error(self, request, client_address):
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionResetError, BrokenPipeError, ConnectionAbortedError)):
+            return
+        super().handle_error(request, client_address)
+
+
+class State:
+    def __init__(self, token, exec_enabled, exec_task_id, exec_command, ping_task_id, ping_target, terminal_enabled=False):
+        self.token = token
+        self.exec_enabled = exec_enabled
+        self.exec_task_id = exec_task_id
+        self.exec_command = exec_command
+        self.ping_task_id = ping_task_id
+        self.recovery_ping_task_id = ping_task_id + 1000
+        self.ping_target = ping_target
+        self.terminal_enabled = terminal_enabled
+        self.upload_seen = threading.Event()
+        self.ws_seen = threading.Event()
+        self.recover_ws_seen = threading.Event()
+        self.recover_report_seen = threading.Event()
+        self.recover_ping_seen = threading.Event()
+        self.handshake_fail_seen = threading.Event()
+        self.report_seen = threading.Event()
+        self.first_pull_seen = threading.Event()
+        self.second_pull_seen = threading.Event()
+        self.ping_seen = threading.Event()
+        self.task_result_seen = threading.Event()
+        self.terminal_seen = threading.Event()
+        self.error = None
+        self.lock = threading.Lock()
+        self.report_count = 0
+        self.pull_count = 0
+
+    def set_error(self, message):
+        with self.lock:
+            if self.error is None:
+                self.error = message
+
+
+def websocket_accept(key):
+    magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+    return base64.b64encode(hashlib.sha1((key + magic).encode("ascii")).digest()).decode("ascii")
+
+
+def read_exact(sock, n):
+    out = bytearray()
+    while len(out) < n:
+        chunk = sock.recv(n - len(out))
+        if not chunk:
+            raise EOFError("socket closed")
+        out.extend(chunk)
+    return bytes(out)
+
+
+def read_ws_frame(sock, timeout):
+    old_timeout = sock.gettimeout()
+    sock.settimeout(timeout)
+    try:
+        first = read_exact(sock, 2)
+        opcode = first[0] & 0x0F
+        masked = bool(first[1] & 0x80)
+        length = first[1] & 0x7F
+        if length == 126:
+            length = int.from_bytes(read_exact(sock, 2), "big")
+        elif length == 127:
+            length = int.from_bytes(read_exact(sock, 8), "big")
+        mask = read_exact(sock, 4) if masked else b""
+        payload = bytearray(read_exact(sock, length))
+        if masked:
+            for i in range(len(payload)):
+                payload[i] ^= mask[i % 4]
+        return opcode, bytes(payload)
+    except socket.timeout as exc:
+        raise TimeoutError() from exc
+    finally:
+        sock.settimeout(old_timeout)
+
+
+def write_ws_frame(out, opcode, payload):
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    if length < 126:
+        header.append(length)
+    elif length <= 0xFFFF:
+        header.append(126)
+        header.extend(length.to_bytes(2, "big"))
+    else:
+        header.append(127)
+        header.extend(length.to_bytes(8, "big"))
+    data = bytes(header) + payload
+    if hasattr(out, "sendall"):
+        out.sendall(data)
+    else:
+        out.write(data)
+        out.flush()
+
+
+def terminate(proc):
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def drain_output(pipe, lines):
+    if pipe is None:
+        return
+    for line in pipe:
+        lines.append(line)
+
+
+def exec_command():
+    if os.name == "nt":
+        return "[Console]::Out.Write('v2-exec-ok')"
+    return "printf v2-exec-ok"
+
+
+def maybe_decode_gzip(handler, body):
+    if handler.headers.get("Content-Encoding", "").lower() != "gzip":
+        return body
+    import gzip
+    return gzip.decompress(body)
+
+
+def expect_gzip(handler, state, context):
+    if handler.headers.get("Content-Encoding", "").lower() != "gzip":
+        state.set_error(f"{context}: missing gzip content-encoding")
+        send_plain(handler, 400, b"missing gzip")
+        return False
+    return True
+
+
+def expect_keys(payload, keys, context):
+    for key in keys:
+        if key not in payload:
+            raise ValueError(f"{context}: missing {key}")
+
+
+def validate_basic_info_rpc(body):
+    if body.get("jsonrpc") != "2.0":
+        raise ValueError("basicInfo: bad jsonrpc")
+    if body.get("method") != "agent.basicInfo":
+        raise ValueError(f"basicInfo: bad method {body.get('method')!r}")
+    params = body.get("params")
+    if not isinstance(params, dict):
+        raise ValueError("basicInfo: missing params")
+    info = params.get("info")
+    if not isinstance(info, dict):
+        raise ValueError("basicInfo: missing info")
+    expect_keys(info, ("cpu_name", "cpu_cores", "arch", "os", "mem_total", "version"), "basicInfo")
+
+
+def validate_report_rpc(body):
+    if body.get("jsonrpc") != "2.0":
+        raise ValueError("report: bad jsonrpc")
+    if body.get("method") != "agent.report":
+        raise ValueError(f"report: bad method {body.get('method')!r}")
+    params = body.get("params")
+    if not isinstance(params, dict):
+        raise ValueError("report: missing params")
+    report = params.get("report")
+    if not isinstance(report, dict):
+        raise ValueError("report: missing report payload")
+    expect_keys(report, ("cpu", "ram", "load", "disk", "network", "connections", "uptime", "process"), "report")
+    return params
+
+
+def validate_ping_result_rpc(body, ping_task_id):
+    if body.get("jsonrpc") != "2.0":
+        raise ValueError("pingResult: bad jsonrpc")
+    if body.get("method") != "agent.pingResult":
+        raise ValueError(f"pingResult: bad method {body.get('method')!r}")
+    params = body.get("params")
+    if not isinstance(params, dict):
+        raise ValueError("pingResult: missing params")
+    if params.get("task_id") != ping_task_id:
+        raise ValueError(f"pingResult: bad task_id {params.get('task_id')!r}")
+    if params.get("ping_type") != "tcp":
+        raise ValueError(f"pingResult: bad ping_type {params.get('ping_type')!r}")
+    if not isinstance(params.get("value"), int) or params["value"] < 0:
+        raise ValueError(f"pingResult: bad value {params.get('value')!r}")
+    if not params.get("finished_at"):
+        raise ValueError("pingResult: missing finished_at")
+
+
+def validate_task_result(body, task_id, expected_output):
+    if body.get("task_id") != task_id:
+        raise ValueError(f"taskResult: bad task_id {body.get('task_id')!r}")
+    if body.get("exit_code") != 0:
+        raise ValueError(f"taskResult: bad exit_code {body.get('exit_code')!r}")
+    if expected_output not in body.get("result", ""):
+        raise ValueError(f"taskResult: missing output {expected_output!r}")
+    if not body.get("finished_at"):
+        raise ValueError("taskResult: missing finished_at")
+
+
+def jsonrpc_success(id_value=None, result=None):
+    payload = {"jsonrpc": "2.0", "result": result if result is not None else {"status": "ok"}}
+    if id_value is not None:
+        payload["id"] = id_value
+    return payload
+
+
+def send_plain(handler, code, body):
+    handler.send_response(code)
+    handler.send_header("Content-Type", "text/plain")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def send_json(handler, payload):
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(200)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def make_ws_handler(state):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, fmt, *args):
+            return
+
+        def do_POST(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/api/clients/v2/rpc":
+                self.handle_rpc_post(parsed)
+            elif parsed.path == "/api/clients/task/result":
+                self.handle_task_result(parsed)
+            else:
+                send_plain(self, 404, b"not found")
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/api/clients/v2/rpc":
+                self.handle_ws(parsed)
+            elif parsed.path == "/api/clients/terminal":
+                self.handle_terminal(parsed)
+            else:
+                send_plain(self, 404, b"not found")
+
+        def read_body(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            return self.rfile.read(length)
+
+        def token_ok(self, parsed):
+            return parse_qs(parsed.query).get("token", [""])[0] == state.token
+
+        def handle_rpc_post(self, parsed):
+            if not self.token_ok(parsed):
+                send_plain(self, 403, b"bad token")
+                state.set_error("bad v2 rpc token")
+                return
+            body = self.read_body()
+            try:
+                payload = json.loads(maybe_decode_gzip(self, body).decode("utf-8"))
+                validate_basic_info_rpc(payload)
+            except Exception as exc:
+                state.set_error(f"bad v2 basic info payload: {exc}; body={body!r}")
+                send_plain(self, 400, b"bad payload")
+                return
+            state.upload_seen.set()
+            send_json(self, jsonrpc_success(result={"status": "ok"}))
+
+        def handle_task_result(self, parsed):
+            if not self.token_ok(parsed):
+                send_plain(self, 403, b"bad token")
+                state.set_error("bad task result token")
+                return
+            body = self.read_body()
+            try:
+                payload = json.loads(body.decode("utf-8"))
+                validate_task_result(payload, state.exec_task_id, "v2-exec-ok")
+            except Exception as exc:
+                state.set_error(f"bad task result payload: {exc}; body={body!r}")
+                send_plain(self, 400, b"bad payload")
+                return
+            state.task_result_seen.set()
+            send_plain(self, 200, b"ok")
+
+        def handle_ws(self, parsed):
+            if not self.token_ok(parsed):
+                send_plain(self, 403, b"bad token")
+                state.set_error("bad websocket token")
+                return
+            key = self.headers.get("Sec-WebSocket-Key")
+            if not key:
+                send_plain(self, 400, b"missing websocket key")
+                return
+            self.send_response(101, "Switching Protocols")
+            self.send_header("Upgrade", "websocket")
+            self.send_header("Connection", "Upgrade")
+            self.send_header("Sec-WebSocket-Accept", websocket_accept(key))
+            self.end_headers()
+            self.wfile.flush()
+            self.close_connection = True
+            state.ws_seen.set()
+
+            sent = False
+            deadline = time.monotonic() + 25
+            while time.monotonic() < deadline:
+                try:
+                    opcode, payload = read_ws_frame(self.connection, 1.0)
+                except TimeoutError:
+                    if state.report_seen.is_set() and state.ping_seen.is_set() and (not state.exec_enabled or state.task_result_seen.is_set()):
+                        return
+                    continue
+                except Exception as exc:
+                    state.set_error(f"v2 websocket read failed: {exc}")
+                    return
+
+                if opcode == 0x8:
+                    return
+                if opcode == 0x9:
+                    write_ws_frame(self.connection, 0xA, payload)
+                    continue
+                if opcode != 0x1:
+                    continue
+
+                try:
+                    message = json.loads(payload.decode("utf-8", errors="replace"))
+                except Exception as exc:
+                    state.set_error(f"bad websocket json: {exc}; payload={payload!r}")
+                    return
+
+                method = message.get("method")
+                if method == "agent.report":
+                    try:
+                        validate_report_rpc(message)
+                    except Exception as exc:
+                        state.set_error(str(exc))
+                        return
+                    state.report_count += 1
+                    state.report_seen.set()
+                    if not sent:
+                        write_ws_frame(self.connection, 0x1, json.dumps({
+                            "jsonrpc": "2.0",
+                            "method": "agent.ping",
+                            "params": {
+                                "ping_task_id": state.ping_task_id,
+                                "ping_type": "tcp",
+                                "ping_target": state.ping_target,
+                            },
+                        }).encode("utf-8"))
+                        if state.exec_enabled:
+                            write_ws_frame(self.connection, 0x1, json.dumps({
+                                "jsonrpc": "2.0",
+                                "method": "agent.exec",
+                                "params": {
+                                    "task_id": state.exec_task_id,
+                                    "command": state.exec_command,
+                                },
+                            }).encode("utf-8"))
+                        if state.terminal_enabled:
+                            write_ws_frame(self.connection, 0x1, json.dumps({
+                                "jsonrpc": "2.0",
+                                "method": "agent.terminal.request",
+                                "params": {
+                                    "request_id": "term-v2-ws",
+                                },
+                            }).encode("utf-8"))
+                        sent = True
+                elif method == "agent.pingResult":
+                    try:
+                        validate_ping_result_rpc(message, state.ping_task_id)
+                    except Exception as exc:
+                        state.set_error(str(exc))
+                        return
+                    state.ping_seen.set()
+
+                if self.done():
+                    return
+
+        def done(self):
+            if not state.report_seen.is_set() or not state.ping_seen.is_set():
+                return False
+            if state.exec_enabled and not state.task_result_seen.is_set():
+                return False
+            if state.terminal_enabled and not state.terminal_seen.is_set():
+                return False
+            return True
+
+        def handle_terminal(self, parsed):
+            if not self.token_ok(parsed):
+                send_plain(self, 403, b"bad token")
+                state.set_error("bad terminal token")
+                return
+            if parse_qs(parsed.query).get("id", [""])[0] != "term-v2-ws":
+                send_plain(self, 403, b"bad terminal id")
+                state.set_error("bad terminal id")
+                return
+            key = self.headers.get("Sec-WebSocket-Key")
+            if not key:
+                send_plain(self, 400, b"missing websocket key")
+                return
+            self.send_response(101, "Switching Protocols")
+            self.send_header("Upgrade", "websocket")
+            self.send_header("Connection", "Upgrade")
+            self.send_header("Sec-WebSocket-Accept", websocket_accept(key))
+            self.end_headers()
+            self.wfile.flush()
+            self.close_connection = True
+            write_ws_frame(self.connection, 0x1, json.dumps({"type": "resize", "cols": 100, "rows": 30}).encode("utf-8"))
+            time.sleep(1.0)
+            write_ws_frame(self.connection, 0x1, json.dumps({"type": "input", "input": "printf terminal-v2-ok\r\nexit\r\n"}).encode("utf-8"))
+            deadline = time.monotonic() + 15
+            seen = bytearray()
+            while time.monotonic() < deadline:
+                try:
+                    opcode, payload = read_ws_frame(self.connection, 1.0)
+                except TimeoutError:
+                    continue
+                except Exception as exc:
+                    state.set_error(f"terminal ws read failed: {exc}")
+                    return
+                if opcode == 0x8:
+                    return
+                if opcode in (0x1, 0x2):
+                    seen.extend(payload)
+                    if b"terminal-v2-ok" in seen:
+                        state.terminal_seen.set()
+                        write_ws_frame(self.connection, 0x8, b"")
+                        return
+            state.set_error(f"terminal output missing: {seen[-200:]!r}")
+
+    return Handler
+
+
+def make_post_fallback_handler(state, recover_ws=False):
+    expected_ack_ids = ["ev-msg-1", "ev-ping-1"] + (["ev-exec-1"] if state.exec_enabled else [])
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, fmt, *args):
+            return
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/api/clients/v2/rpc":
+                if parse_qs(parsed.query).get("token", [""])[0] != state.token:
+                    send_plain(self, 403, b"bad token")
+                    state.set_error("bad v2 fallback handshake token")
+                    return
+                if recover_ws and state.second_pull_seen.is_set() and state.ping_seen.is_set():
+                    self.handle_recovery_ws()
+                    return
+                state.handshake_fail_seen.set()
+                send_plain(self, 200, b"not websocket")
+                return
+            send_plain(self, 404, b"not found")
+
+        def do_POST(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/api/clients/v2/rpc":
+                self.handle_rpc(parsed)
+            elif parsed.path == "/api/clients/task/result":
+                self.handle_task_result(parsed)
+            else:
+                send_plain(self, 404, b"not found")
+
+        def read_body(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            return self.rfile.read(length)
+
+        def token_ok(self, parsed):
+            return parse_qs(parsed.query).get("token", [""])[0] == state.token
+
+        def handle_rpc(self, parsed):
+            if not self.token_ok(parsed):
+                send_plain(self, 403, b"bad token")
+                state.set_error("bad v2 rpc token")
+                return
+            if not expect_gzip(self, state, "v2 rpc"):
+                return
+            body = self.read_body()
+            try:
+                payload = json.loads(maybe_decode_gzip(self, body).decode("utf-8"))
+            except Exception as exc:
+                state.set_error(f"bad fallback rpc json: {exc}; body={body!r}")
+                send_plain(self, 400, b"bad payload")
+                return
+
+            method = payload.get("method")
+            if method == "agent.basicInfo":
+                try:
+                    validate_basic_info_rpc(payload)
+                except Exception as exc:
+                    state.set_error(str(exc))
+                    send_plain(self, 400, b"bad payload")
+                    return
+                state.upload_seen.set()
+                send_json(self, jsonrpc_success(result={"status": "ok"}))
+                return
+
+            if method == "agent.pull":
+                params = payload.get("params")
+                if not isinstance(params, dict):
+                    state.set_error("pull: missing params")
+                    send_plain(self, 400, b"bad payload")
+                    return
+                ack_ids = params.get("ack_event_ids")
+                if not isinstance(ack_ids, list):
+                    state.set_error("pull: missing ack_event_ids")
+                    send_plain(self, 400, b"bad payload")
+                    return
+                state.pull_count += 1
+                if not state.first_pull_seen.is_set():
+                    if ack_ids != []:
+                        state.set_error(f"pull#1: expected empty ack_event_ids, got {ack_ids!r}")
+                        send_plain(self, 400, b"bad payload")
+                        return
+                    state.first_pull_seen.set()
+                    events = [
+                        {"id": "ev-msg-1", "method": "agent.message", "params": {"text": "hello"}},
+                        {
+                            "id": "ev-ping-1",
+                            "method": "agent.ping",
+                            "params": {
+                                "ping_task_id": state.ping_task_id,
+                                "ping_type": "tcp",
+                                "ping_target": state.ping_target,
+                            },
+                        },
+                    ]
+                    if state.exec_enabled:
+                        events.append({
+                            "id": "ev-exec-1",
+                            "method": "agent.exec",
+                            "params": {
+                                "task_id": state.exec_task_id,
+                                "command": state.exec_command,
+                            },
+                        })
+                    send_json(self, jsonrpc_success(payload.get("id"), {"events": events, "status": "ok"}))
+                    return
+                if not state.report_seen.is_set():
+                    state.set_error(f"pull before report ack drain: {ack_ids!r}")
+                    send_plain(self, 400, b"bad payload")
+                    return
+                if ack_ids != []:
+                    state.set_error(f"pull#2: expected cleared ack_event_ids, got {ack_ids!r}")
+                    send_plain(self, 400, b"bad payload")
+                    return
+                state.second_pull_seen.set()
+                send_json(self, jsonrpc_success(payload.get("id"), {"events": [], "status": "ok"}))
+                return
+
+            if method == "agent.report":
+                try:
+                    params = validate_report_rpc(payload)
+                except Exception as exc:
+                    state.set_error(str(exc))
+                    send_plain(self, 400, b"bad payload")
+                    return
+                ack_ids = params.get("ack_event_ids")
+                if ack_ids == expected_ack_ids:
+                    state.report_seen.set()
+                elif ack_ids == []:
+                    pass
+                else:
+                    state.set_error(f"report: bad ack_event_ids {ack_ids!r}, expected {expected_ack_ids!r}")
+                    send_plain(self, 400, b"bad payload")
+                    return
+                state.report_count += 1
+                send_json(self, jsonrpc_success(payload.get("id"), {"status": "ok"}))
+                return
+
+            if method == "agent.pingResult":
+                try:
+                    validate_ping_result_rpc(payload, state.ping_task_id)
+                except Exception as exc:
+                    state.set_error(str(exc))
+                    send_plain(self, 400, b"bad payload")
+                    return
+                state.ping_seen.set()
+                send_json(self, jsonrpc_success(result={"status": "ok"}))
+                return
+
+            state.set_error(f"unexpected v2 rpc method: {method!r}")
+            send_plain(self, 400, b"bad payload")
+
+        def handle_task_result(self, parsed):
+            if not self.token_ok(parsed):
+                send_plain(self, 403, b"bad token")
+                state.set_error("bad task result token")
+                return
+            body = self.read_body()
+            try:
+                payload = json.loads(body.decode("utf-8"))
+                validate_task_result(payload, state.exec_task_id, "v2-exec-ok")
+            except Exception as exc:
+                state.set_error(f"bad task result payload: {exc}; body={body!r}")
+                send_plain(self, 400, b"bad payload")
+                return
+            state.task_result_seen.set()
+            send_plain(self, 200, b"ok")
+
+        def handle_recovery_ws(self):
+            key = self.headers.get("Sec-WebSocket-Key")
+            if not key:
+                send_plain(self, 400, b"missing websocket key")
+                return
+            self.send_response(101, "Switching Protocols")
+            self.send_header("Upgrade", "websocket")
+            self.send_header("Connection", "Upgrade")
+            self.send_header("Sec-WebSocket-Accept", websocket_accept(key))
+            self.end_headers()
+            self.wfile.flush()
+            self.close_connection = True
+            state.recover_ws_seen.set()
+
+            sent_ping = False
+            deadline = time.monotonic() + 25
+            while time.monotonic() < deadline:
+                try:
+                    opcode, payload = read_ws_frame(self.connection, 1.0)
+                except TimeoutError:
+                    if state.recover_report_seen.is_set() and state.recover_ping_seen.is_set():
+                        return
+                    continue
+                except Exception as exc:
+                    state.set_error(f"recovery websocket read failed: {exc}")
+                    return
+
+                if opcode == 0x8:
+                    return
+                if opcode == 0x9:
+                    write_ws_frame(self.connection, 0xA, payload)
+                    continue
+                if opcode != 0x1:
+                    continue
+
+                try:
+                    message = json.loads(payload.decode("utf-8", errors="replace"))
+                except Exception as exc:
+                    state.set_error(f"bad recovery websocket json: {exc}; payload={payload!r}")
+                    return
+
+                method = message.get("method")
+                if method == "agent.report":
+                    try:
+                        validate_report_rpc(message)
+                    except Exception as exc:
+                        state.set_error(str(exc))
+                        return
+                    state.recover_report_seen.set()
+                    if not sent_ping:
+                        write_ws_frame(self.connection, 0x1, json.dumps({
+                            "jsonrpc": "2.0",
+                            "method": "agent.ping",
+                            "params": {
+                                "ping_task_id": state.recovery_ping_task_id,
+                                "ping_type": "tcp",
+                                "ping_target": state.ping_target,
+                            },
+                        }).encode("utf-8"))
+                        sent_ping = True
+                elif method == "agent.pingResult":
+                    try:
+                        validate_ping_result_rpc(message, state.recovery_ping_task_id)
+                    except Exception as exc:
+                        state.set_error(str(exc))
+                        return
+                    state.recover_ping_seen.set()
+
+                if state.recover_report_seen.is_set() and state.recover_ping_seen.is_set():
+                    return
+
+    return Handler
+
+
+def run_agent(agent_path, endpoint, token, timeout, protocol_version, no_exec):
+    cmd = [
+        os.path.abspath(agent_path),
+        "--endpoint",
+        endpoint,
+        "--token",
+        token,
+        "--disable-auto-update",
+        "--protocol-version",
+        str(protocol_version),
+        "--max-retries",
+        "0",
+        "--reconnect-interval",
+        "5",
+        "--info-report-interval",
+        "60",
+        "--custom-ipv4",
+        "203.0.113.20",
+        "--custom-ipv6",
+        "2001:db8::20",
+    ]
+    if no_exec:
+        cmd.append("--disable-web-ssh")
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    output_lines = []
+    threading.Thread(target=drain_output, args=(proc.stdout, output_lines), daemon=True).start()
+    return proc, output_lines, time.monotonic() + timeout
+
+
+def wait_for_ws(state, proc, output_lines, deadline):
+    while time.monotonic() < deadline:
+        if state.error:
+            raise RuntimeError(f"{state.error}\n{''.join(output_lines[-120:])}")
+        if state.upload_seen.is_set() and state.ws_seen.is_set() and state.report_seen.is_set() and state.ping_seen.is_set() and (not state.exec_enabled or state.task_result_seen.is_set()) and (not state.terminal_enabled or state.terminal_seen.is_set()):
+            return
+        if proc.poll() is not None:
+            raise RuntimeError(f"agent exited early: {proc.returncode}\n{''.join(output_lines[-120:])}")
+        time.sleep(0.05)
+    raise RuntimeError(
+        "timeout waiting for v2 websocket flow; "
+        f"upload={state.upload_seen.is_set()} ws={state.ws_seen.is_set()} report={state.report_seen.is_set()} "
+        f"ping={state.ping_seen.is_set()} task={state.task_result_seen.is_set()} terminal={state.terminal_seen.is_set()}\n{''.join(output_lines[-120:])}"
+    )
+
+
+def wait_for_post_fallback(state, proc, output_lines, deadline):
+    while time.monotonic() < deadline:
+        if state.error:
+            raise RuntimeError(f"{state.error}\n{''.join(output_lines[-120:])}")
+        if (
+            state.upload_seen.is_set()
+            and state.handshake_fail_seen.is_set()
+            and state.first_pull_seen.is_set()
+            and state.report_seen.is_set()
+            and state.second_pull_seen.is_set()
+            and state.ping_seen.is_set()
+            and (not state.exec_enabled or state.task_result_seen.is_set())
+        ):
+            return
+        if proc.poll() is not None:
+            raise RuntimeError(f"agent exited early: {proc.returncode}\n{''.join(output_lines[-120:])}")
+        time.sleep(0.05)
+    raise RuntimeError(
+        "timeout waiting for v2 post fallback flow; "
+        f"upload={state.upload_seen.is_set()} handshake_fail={state.handshake_fail_seen.is_set()} "
+        f"pull1={state.first_pull_seen.is_set()} report={state.report_seen.is_set()} "
+        f"pull2={state.second_pull_seen.is_set()} ping={state.ping_seen.is_set()} task={state.task_result_seen.is_set()}\n"
+        f"{''.join(output_lines[-120:])}"
+    )
+
+
+def wait_for_post_recover(state, proc, output_lines, deadline):
+    while time.monotonic() < deadline:
+        if state.error:
+            raise RuntimeError(f"{state.error}\n{''.join(output_lines[-120:])}")
+        if (
+            state.upload_seen.is_set()
+            and state.handshake_fail_seen.is_set()
+            and state.first_pull_seen.is_set()
+            and state.report_seen.is_set()
+            and state.second_pull_seen.is_set()
+            and state.ping_seen.is_set()
+            and state.recover_ws_seen.is_set()
+            and state.recover_report_seen.is_set()
+            and state.recover_ping_seen.is_set()
+            and (not state.exec_enabled or state.task_result_seen.is_set())
+        ):
+            return
+        if proc.poll() is not None:
+            raise RuntimeError(f"agent exited early: {proc.returncode}\n{''.join(output_lines[-120:])}")
+        time.sleep(0.05)
+    raise RuntimeError(
+        "timeout waiting for v2 post recovery flow; "
+        f"upload={state.upload_seen.is_set()} handshake_fail={state.handshake_fail_seen.is_set()} "
+        f"pull1={state.first_pull_seen.is_set()} report={state.report_seen.is_set()} "
+        f"pull2={state.second_pull_seen.is_set()} ping={state.ping_seen.is_set()} "
+        f"recover_ws={state.recover_ws_seen.is_set()} recover_report={state.recover_report_seen.is_set()} "
+        f"recover_ping={state.recover_ping_seen.is_set()} task={state.task_result_seen.is_set()}\n"
+        f"{''.join(output_lines[-120:])}"
+    )
+
+
+def run_ws(args):
+    token = "v2-ws-token"
+    exec_enabled = not args.no_exec
+    exec_task_id = "exec-v2-ws"
+    ping_task_id = 701
+    tcp = TcpAcceptServer(("127.0.0.1", 0), TcpAcceptHandler)
+    threading.Thread(target=tcp.serve_forever, daemon=True).start()
+    ping_target = f"127.0.0.1:{tcp.server_address[1]}"
+    state = State(token, exec_enabled, exec_task_id, exec_command(), ping_task_id, ping_target, terminal_enabled=args.terminal)
+    server = QuietThreadingHTTPServer(("127.0.0.1", 0), make_ws_handler(state))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    endpoint = f"http://127.0.0.1:{server.server_address[1]}"
+    proc, output_lines, deadline = run_agent(args.agent, endpoint, token, args.timeout, 2, args.no_exec)
+    try:
+        wait_for_ws(state, proc, output_lines, deadline)
+        print("mock komari v2 websocket e2e ok")
+        return 0
+    except Exception as exc:
+        print(f"v2 websocket e2e failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        terminate(proc)
+        server.shutdown()
+        server.server_close()
+        tcp.shutdown()
+        tcp.server_close()
+
+
+def run_post_fallback(args):
+    token = "v2-post-token"
+    exec_enabled = not args.no_exec
+    exec_task_id = "exec-v2-post"
+    ping_task_id = 702
+    tcp = TcpAcceptServer(("127.0.0.1", 0), TcpAcceptHandler)
+    threading.Thread(target=tcp.serve_forever, daemon=True).start()
+    ping_target = f"127.0.0.1:{tcp.server_address[1]}"
+    state = State(token, exec_enabled, exec_task_id, exec_command(), ping_task_id, ping_target)
+    server = QuietThreadingHTTPServer(("127.0.0.1", 0), make_post_fallback_handler(state))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    endpoint = f"http://127.0.0.1:{server.server_address[1]}"
+    proc, output_lines, deadline = run_agent(args.agent, endpoint, token, args.timeout, 2, args.no_exec)
+    try:
+        wait_for_post_fallback(state, proc, output_lines, deadline)
+        print("mock komari v2 post fallback e2e ok")
+        return 0
+    except Exception as exc:
+        print(f"v2 post fallback e2e failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        terminate(proc)
+        server.shutdown()
+        server.server_close()
+        tcp.shutdown()
+        tcp.server_close()
+
+
+def run_post_recover(args):
+    token = "v2-recover-token"
+    exec_enabled = not args.no_exec
+    exec_task_id = "exec-v2-recover"
+    ping_task_id = 703
+    tcp = TcpAcceptServer(("127.0.0.1", 0), TcpAcceptHandler)
+    threading.Thread(target=tcp.serve_forever, daemon=True).start()
+    ping_target = f"127.0.0.1:{tcp.server_address[1]}"
+    state = State(token, exec_enabled, exec_task_id, exec_command(), ping_task_id, ping_target)
+    server = QuietThreadingHTTPServer(("127.0.0.1", 0), make_post_fallback_handler(state, recover_ws=True))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    endpoint = f"http://127.0.0.1:{server.server_address[1]}"
+    proc, output_lines, deadline = run_agent(args.agent, endpoint, token, args.timeout, 2, args.no_exec)
+    try:
+        wait_for_post_recover(state, proc, output_lines, deadline)
+        print("mock komari v2 post recovery e2e ok")
+        return 0
+    except Exception as exc:
+        print(f"v2 post recovery e2e failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        terminate(proc)
+        server.shutdown()
+        server.server_close()
+        tcp.shutdown()
+        tcp.server_close()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    ws = sub.add_parser("ws")
+    ws.add_argument("agent")
+    ws.add_argument("--timeout", type=float, default=30.0)
+    ws.add_argument("--no-exec", action="store_true")
+    ws.add_argument("--terminal", action="store_true")
+
+    post = sub.add_parser("post-fallback")
+    post.add_argument("agent")
+    post.add_argument("--timeout", type=float, default=30.0)
+    post.add_argument("--no-exec", action="store_true")
+
+    recover = sub.add_parser("post-recover")
+    recover.add_argument("agent")
+    recover.add_argument("--timeout", type=float, default=35.0)
+    recover.add_argument("--no-exec", action="store_true")
+
+    args = parser.parse_args()
+    if args.mode == "ws":
+        return run_ws(args)
+    if args.mode == "post-fallback":
+        return run_post_fallback(args)
+    if args.mode == "post-recover":
+        return run_post_recover(args)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config.zig
+++ b/src/config.zig
@@ -21,6 +21,9 @@ pub const Config = struct {
     max_retries: i32 = 3,
     reconnect_interval: i32 = 5,
     info_report_interval: i32 = 5,
+    protocol_version: i32 = 2,
+    disable_compression: bool = false,
+    prefer_ip_version: []const u8 = "",
     include_nics: []const u8 = "",
     exclude_nics: []const u8 = "",
     include_mountpoints: []const u8 = "",
@@ -59,6 +62,9 @@ pub const Config = struct {
         try setIntJson(object, "max_retries", &self.max_retries);
         try setIntJson(object, "reconnect_interval", &self.reconnect_interval);
         try setIntJson(object, "info_report_interval", &self.info_report_interval);
+        try setIntJson(object, "protocol_version", &self.protocol_version);
+        try setBoolJson(object, "disable_compression", &self.disable_compression);
+        try setStringJson(allocator, object, "prefer_ip_version", &self.prefer_ip_version);
         try setStringJson(allocator, object, "include_nics", &self.include_nics);
         try setStringJson(allocator, object, "exclude_nics", &self.exclude_nics);
         try setStringJson(allocator, object, "include_mountpoints", &self.include_mountpoints);
@@ -96,6 +102,8 @@ pub const Config = struct {
         setIntEnv("AGENT_MAX_RETRIES", &self.max_retries);
         setIntEnv("AGENT_RECONNECT_INTERVAL", &self.reconnect_interval);
         setIntEnv("AGENT_INFO_REPORT_INTERVAL", &self.info_report_interval);
+        setIntEnv("AGENT_PROTOCOL_VERSION", &self.protocol_version);
+        setBoolEnv("AGENT_DISABLE_COMPRESSION", &self.disable_compression);
         try setStringEnv(allocator, "AGENT_INCLUDE_NICS", &self.include_nics);
         try setStringEnv(allocator, "AGENT_EXCLUDE_NICS", &self.exclude_nics);
         try setStringEnv(allocator, "AGENT_INCLUDE_MOUNTPOINTS", &self.include_mountpoints);
@@ -105,6 +113,7 @@ pub const Config = struct {
         setBoolEnv("AGENT_MEMORY_INCLUDE_CACHE", &self.memory_include_cache);
         setBoolEnv("AGENT_MEMORY_REPORT_RAW_USED", &self.memory_report_raw_used);
         try setStringEnv(allocator, "AGENT_CUSTOM_DNS", &self.custom_dns);
+        try setStringEnv(allocator, "AGENT_PREFER_IP_VERSION", &self.prefer_ip_version);
         setBoolEnv("AGENT_ENABLE_GPU", &self.enable_gpu);
         setBoolEnv("AGENT_SHOW_WARNING", &self.show_warning);
         setBoolEnv("AGENT_DEBUG_LOG", &self.debug_log);
@@ -113,6 +122,14 @@ pub const Config = struct {
         setBoolEnv("AGENT_GET_IP_ADDR_FROM_NIC", &self.get_ip_addr_from_nic);
         try setStringEnv(allocator, "HOST_PROC", &self.host_proc);
         try setStringEnv(allocator, "AGENT_CONFIG_FILE", &self.config_file);
+    }
+
+    pub fn normalize(self: *Config) !void {
+        if (self.protocol_version == 0) self.protocol_version = 2;
+        if (self.protocol_version != 1 and self.protocol_version != 2) return error.InvalidProtocolVersion;
+        if (self.prefer_ip_version.len != 0 and !std.mem.eql(u8, self.prefer_ip_version, "4") and !std.mem.eql(u8, self.prefer_ip_version, "6")) {
+            return error.InvalidPreferIpVersion;
+        }
     }
 };
 
@@ -143,6 +160,10 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Config
             cfg.reconnect_interval = try std.fmt.parseInt(i32, v, 10);
         } else if (optionValue(arg, "--info-report-interval")) |v| {
             cfg.info_report_interval = try std.fmt.parseInt(i32, v, 10);
+        } else if (optionValue(arg, "--protocol-version")) |v| {
+            cfg.protocol_version = try std.fmt.parseInt(i32, v, 10);
+        } else if (optionValue(arg, "--prefer-ip-version")) |v| {
+            cfg.prefer_ip_version = try allocator.dupe(u8, v);
         } else if (optionValue(arg, "--include-nics")) |v| {
             cfg.include_nics = try allocator.dupe(u8, v);
         } else if (optionValue(arg, "--exclude-nics")) |v| {
@@ -173,6 +194,8 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Config
             cfg.memory_include_cache = v;
         } else if (boolOptionValue(arg, "--memory-exclude-bcf")) |v| {
             cfg.memory_report_raw_used = v;
+        } else if (boolOptionValue(arg, "--disable-compression")) |v| {
+            cfg.disable_compression = v;
         } else if (boolOptionValue(arg, "--gpu")) |v| {
             cfg.enable_gpu = v;
         } else if (boolOptionValue(arg, "--show-warning")) |v| {
@@ -201,6 +224,10 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Config
             if (nextValue(args, &i)) |v| cfg.reconnect_interval = try std.fmt.parseInt(i32, v, 10);
         } else if (std.mem.eql(u8, arg, "--info-report-interval")) {
             if (nextValue(args, &i)) |v| cfg.info_report_interval = try std.fmt.parseInt(i32, v, 10);
+        } else if (std.mem.eql(u8, arg, "--protocol-version")) {
+            if (nextValue(args, &i)) |v| cfg.protocol_version = try std.fmt.parseInt(i32, v, 10);
+        } else if (std.mem.eql(u8, arg, "--prefer-ip-version")) {
+            if (nextValue(args, &i)) |v| cfg.prefer_ip_version = try allocator.dupe(u8, v);
         } else if (std.mem.eql(u8, arg, "--include-nics")) {
             if (nextValue(args, &i)) |v| cfg.include_nics = try allocator.dupe(u8, v);
         } else if (std.mem.eql(u8, arg, "--exclude-nics")) {
@@ -217,6 +244,8 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Config
             cfg.memory_include_cache = true;
         } else if (std.mem.eql(u8, arg, "--memory-exclude-bcf")) {
             cfg.memory_report_raw_used = true;
+        } else if (std.mem.eql(u8, arg, "--disable-compression")) {
+            cfg.disable_compression = true;
         } else if (std.mem.eql(u8, arg, "--custom-dns")) {
             if (nextValue(args, &i)) |v| cfg.custom_dns = try allocator.dupe(u8, v);
         } else if (std.mem.eql(u8, arg, "--gpu")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@ const ip = @import("protocol/ip.zig");
 const netstatic = @import("report_netstatic");
 const ping = @import("protocol/ping.zig");
 const report_ws = @import("protocol/report_ws.zig");
+const v2_state = @import("protocol/v2_state.zig");
 const update = @import("update.zig");
 const version = @import("version.zig");
 const builtin = @import("builtin");
@@ -45,6 +46,9 @@ pub fn main(init: std.process.Init.Minimal) !void {
     var cfg = try config.parseArgs(config_allocator, args);
     try cfg.loadEnv(config_allocator);
     if (cfg.config_file.len != 0) try cfg.loadJsonFile(config_allocator, cfg.config_file);
+    try cfg.normalize();
+    v2_state.initRequestedProtocolVersion(cfg.protocol_version);
+    v2_state.resetConnectionProtocolVersion();
     debug.setEnabled(cfg.debug_log);
 
     if (cfg.command == .list_disk) {
@@ -206,7 +210,7 @@ fn uploadBasicInfoOnce(allocator: std.mem.Allocator, cfg: config.Config, allow_e
         debug.log("deferring foreground basic info upload until public IP refresh because IPv4 is empty", .{});
         return error.BasicInfoDeferredUntilPublicIp;
     }
-    const info_json = try basic_info.allocBasicInfoJson(scratch, info, true);
+    const info_json = try basic_info.allocBasicInfoJson(scratch, info, true, true);
     try stdout.print("Basic info ready: {d} bytes\n", .{info_json.len});
     debug.log("basic info prepared: upload_bytes={d} final_ipv4={s} final_ipv6={s}", .{ info_json.len, info.ipv4, info.ipv6 });
     try basic_info.upload(scratch, cfg, info);

--- a/src/platform/common.zig
+++ b/src/platform/common.zig
@@ -3,6 +3,7 @@ pub const CpuInfo = struct {
     name: []const u8 = "Unknown",
     architecture: []const u8 = "unknown",
     cores: u32 = 1,
+    physical_cores: u32 = 0,
     usage: f64 = 0.001,
 };
 

--- a/src/platform/darwin.zig
+++ b/src/platform/darwin.zig
@@ -23,6 +23,7 @@ pub fn basicInfo(allocator: std.mem.Allocator) !common.BasicInfo {
             .name = try commandFirstLine(allocator, &.{ "sysctl", "-n", "machdep.cpu.brand_string" }, "Unknown"),
             .architecture = normalizeArch(@tagName(@import("builtin").cpu.arch)),
             .cores = @intCast(std.Thread.getCpuCount() catch 1),
+            .physical_cores = @intCast(sysctlInt(allocator, "hw.physicalcpu") catch 0),
             .usage = 0.001,
         },
         .os_name = try commandFirstLine(allocator, &.{ "sw_vers", "-productName" }, "macOS"),

--- a/src/platform/freebsd.zig
+++ b/src/platform/freebsd.zig
@@ -25,6 +25,7 @@ pub fn basicInfo(allocator: std.mem.Allocator) !common.BasicInfo {
             .name = try commandFirstLine(allocator, &.{ "sysctl", "-n", "hw.model" }, "Unknown"),
             .architecture = normalizeArch(@tagName(@import("builtin").cpu.arch)),
             .cores = @intCast(std.Thread.getCpuCount() catch 1),
+            .physical_cores = @intCast(sysctlInt("kern.smp.cores") catch 0),
             .usage = 0.001,
         },
         .os_name = try commandJoin(allocator, &.{ "uname", "-sr" }, "FreeBSD"),

--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -33,6 +33,8 @@ var cached_disk: ?CachedDiskSample = null;
 var cached_connections: ?CachedConnectionsSample = null;
 var cached_process: ?CachedProcessSample = null;
 var cached_cpu_cores = std.atomic.Value(u32).init(0);
+const unknown_cpu_physical_cores = std.math.maxInt(u32);
+var cached_cpu_physical_cores = std.atomic.Value(u32).init(unknown_cpu_physical_cores);
 
 const disk_cache_ttl_ms: u64 = 30 * 1000;
 const connections_cache_ttl_ms: u64 = 5 * 1000;
@@ -87,6 +89,7 @@ pub fn basicInfo(allocator: std.mem.Allocator) !common.BasicInfo {
             .name = try cpuName(allocator),
             .architecture = normalizeArch(@tagName(@import("builtin").cpu.arch)),
             .cores = try cpuCoreCount(),
+            .physical_cores = try cpuPhysicalCoreCount(),
             .usage = 0.001,
         },
         .os_name = try osName(allocator),
@@ -135,6 +138,155 @@ fn cpuCoreCount() !u32 {
     const count: u32 = @intCast(try std.Thread.getCpuCount());
     cached_cpu_cores.store(count, .release);
     return count;
+}
+
+fn cpuPhysicalCoreCount() !u32 {
+    const cached = cached_cpu_physical_cores.load(.acquire);
+    if (cached != unknown_cpu_physical_cores) return cached;
+
+    const count = cpuPhysicalCoreCountFromProcCpuInfo() catch 0;
+    cached_cpu_physical_cores.store(count, .release);
+    return count;
+}
+
+fn cpuPhysicalCoreCountFromProcCpuInfo() !u32 {
+    const bytes = compat.readFileAlloc(std.heap.page_allocator, "/proc/cpuinfo", 256 * 1024) catch return 0;
+    defer std.heap.page_allocator.free(bytes);
+    return parseCpuPhysicalCoreCountFromCpuInfo(std.heap.page_allocator, bytes) catch 0;
+}
+
+const CpuCorePair = struct {
+    physical_id: []const u8,
+    core_id: []const u8,
+};
+
+const CpuPackageCoreCount = struct {
+    physical_id: []const u8,
+    cpu_cores: u32,
+};
+
+fn parseCpuPhysicalCoreCountFromCpuInfo(allocator: std.mem.Allocator, bytes: []const u8) !u32 {
+    var pairs: std.ArrayList(CpuCorePair) = .empty;
+    defer {
+        for (pairs.items) |pair| {
+            allocator.free(pair.physical_id);
+            allocator.free(pair.core_id);
+        }
+        pairs.deinit(allocator);
+    }
+
+    var packages: std.ArrayList(CpuPackageCoreCount) = .empty;
+    defer {
+        for (packages.items) |pkg| allocator.free(pkg.physical_id);
+        packages.deinit(allocator);
+    }
+
+    var current_physical_id: ?[]const u8 = null;
+    var current_core_id: ?[]const u8 = null;
+    var current_cpu_cores: ?u32 = null;
+    var saw_physical_id = false;
+
+    defer {
+        if (current_physical_id) |id| allocator.free(id);
+        if (current_core_id) |id| allocator.free(id);
+    }
+
+    var lines = std.mem.splitScalar(u8, bytes, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trim(u8, line_raw, " \t\r");
+        if (line.len == 0) {
+            try flushCpuInfoSection(allocator, &pairs, &packages, &current_physical_id, &current_core_id, &current_cpu_cores);
+            continue;
+        }
+
+        const idx = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const key = std.mem.trim(u8, line[0..idx], " \t");
+        const value = std.mem.trim(u8, line[idx + 1 ..], " \t");
+        if (value.len == 0) continue;
+
+        if (std.ascii.eqlIgnoreCase(key, "physical id")) {
+            if (current_physical_id) |id| allocator.free(id);
+            current_physical_id = try allocator.dupe(u8, value);
+            saw_physical_id = true;
+            continue;
+        }
+
+        if (std.ascii.eqlIgnoreCase(key, "core id")) {
+            if (current_core_id) |id| allocator.free(id);
+            current_core_id = try allocator.dupe(u8, value);
+            continue;
+        }
+
+        if (std.ascii.eqlIgnoreCase(key, "cpu cores")) {
+            current_cpu_cores = std.fmt.parseInt(u32, value, 10) catch null;
+        }
+    }
+
+    try flushCpuInfoSection(allocator, &pairs, &packages, &current_physical_id, &current_core_id, &current_cpu_cores);
+
+    if (pairs.items.len != 0) return @intCast(pairs.items.len);
+    if (packages.items.len != 0 and (saw_physical_id or packages.items.len == 1)) {
+        var total: u32 = 0;
+        for (packages.items) |pkg| total = total +| pkg.cpu_cores;
+        return total;
+    }
+    return 0;
+}
+
+fn flushCpuInfoSection(
+    allocator: std.mem.Allocator,
+    pairs: *std.ArrayList(CpuCorePair),
+    packages: *std.ArrayList(CpuPackageCoreCount),
+    current_physical_id: *?[]const u8,
+    current_core_id: *?[]const u8,
+    current_cpu_cores: *?u32,
+) !void {
+    const physical_id = current_physical_id.* orelse "";
+    if (current_physical_id.* != null and current_core_id.* != null) {
+        const core_id = current_core_id.*.?;
+        if (!cpuCorePairExists(pairs.items, physical_id, core_id)) {
+            try pairs.append(allocator, .{
+                .physical_id = try allocator.dupe(u8, physical_id),
+                .core_id = try allocator.dupe(u8, core_id),
+            });
+        }
+    }
+
+    if (current_cpu_cores.*) |cpu_cores| {
+        if (cpu_cores != 0) try upsertCpuPackageCoreCount(allocator, packages, physical_id, cpu_cores);
+    }
+
+    if (current_physical_id.*) |id| allocator.free(id);
+    if (current_core_id.*) |id| allocator.free(id);
+    current_physical_id.* = null;
+    current_core_id.* = null;
+    current_cpu_cores.* = null;
+}
+
+fn cpuCorePairExists(pairs: []const CpuCorePair, physical_id: []const u8, core_id: []const u8) bool {
+    for (pairs) |pair| {
+        if (std.mem.eql(u8, pair.physical_id, physical_id) and std.mem.eql(u8, pair.core_id, core_id)) return true;
+    }
+    return false;
+}
+
+fn upsertCpuPackageCoreCount(
+    allocator: std.mem.Allocator,
+    packages: *std.ArrayList(CpuPackageCoreCount),
+    physical_id: []const u8,
+    cpu_cores: u32,
+) !void {
+    for (packages.items) |*pkg| {
+        if (std.mem.eql(u8, pkg.physical_id, physical_id)) {
+            if (cpu_cores > pkg.cpu_cores) pkg.cpu_cores = cpu_cores;
+            return;
+        }
+    }
+
+    try packages.append(allocator, .{
+        .physical_id = try allocator.dupe(u8, physical_id),
+        .cpu_cores = cpu_cores,
+    });
 }
 
 pub fn parseOsReleaseName(allocator: std.mem.Allocator, bytes: []const u8) ![]const u8 {
@@ -362,25 +514,85 @@ fn gpuName(allocator: std.mem.Allocator) ![]const u8 {
         if (!std.mem.eql(u8, line, "None")) return line;
         allocator.free(line);
     } else |_| {}
-    if (commandOutputFirstLine(allocator, &.{ "nvidia-smi", "--query-gpu=name", "--format=csv,noheader" })) |line| {
+    if (commandGpuNames(allocator, &.{ "nvidia-smi", "--query-gpu=name", "--format=csv,noheader" })) |line| {
         if (line.len != 0) return line;
         allocator.free(line);
     } else |_| {}
-    if (commandOutputFirstLine(allocator, &.{ "/opt/rocm/bin/rocm-smi", "--showproductname" })) |line| {
+    if (commandGpuNames(allocator, &.{ "/opt/rocm/bin/rocm-smi", "--showproductname" })) |line| {
         if (line.len != 0) return line;
         allocator.free(line);
     } else |_| {}
-    if (commandOutputFirstLine(allocator, &.{ "rocm-smi", "--showproductname" })) |line| {
+    if (commandGpuNames(allocator, &.{ "rocm-smi", "--showproductname" })) |line| {
         if (line.len != 0) return line;
         allocator.free(line);
     } else |_| {}
     return allocator.dupe(u8, "None");
 }
 
+const GpuNameCount = struct {
+    name: []const u8,
+    count: u32,
+};
+
+fn deinitGpuNameCounts(allocator: std.mem.Allocator, counts: *std.ArrayList(GpuNameCount)) void {
+    for (counts.items) |item| allocator.free(item.name);
+    counts.deinit(allocator);
+}
+
+fn appendGpuNameCount(allocator: std.mem.Allocator, counts: *std.ArrayList(GpuNameCount), name_raw: []const u8) !void {
+    const name = std.mem.trim(u8, name_raw, " \t\r\n");
+    if (name.len == 0 or std.mem.eql(u8, name, "None")) return;
+
+    for (counts.items) |*item| {
+        if (std.mem.eql(u8, item.name, name)) {
+            item.count = item.count +| 1;
+            return;
+        }
+    }
+
+    try counts.append(allocator, .{
+        .name = try allocator.dupe(u8, name),
+        .count = 1,
+    });
+}
+
+fn allocFormattedGpuNameCounts(allocator: std.mem.Allocator, counts: []const GpuNameCount) ![]const u8 {
+    if (counts.len == 0) return allocator.dupe(u8, "None");
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+
+    for (counts, 0..) |item, idx| {
+        if (idx != 0) try out.appendSlice(allocator, ", ");
+        if (item.count > 1) {
+            try compat.appendPrint(allocator, &out, "{s} × {d}", .{ item.name, item.count });
+        } else {
+            try compat.appendPrint(allocator, &out, "{s}", .{item.name});
+        }
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+fn commandGpuNames(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
+    const output = try commandOutput(allocator, argv);
+    defer allocator.free(output);
+
+    var counts: std.ArrayList(GpuNameCount) = .empty;
+    defer deinitGpuNameCounts(allocator, &counts);
+
+    var lines = std.mem.splitScalar(u8, output, '\n');
+    while (lines.next()) |line| try appendGpuNameCount(allocator, &counts, line);
+
+    return allocFormattedGpuNameCounts(allocator, counts.items);
+}
+
 fn gpuNameFromLspci(allocator: std.mem.Allocator) ![]const u8 {
     const out = commandOutput(allocator, &.{"lspci"}) catch return allocator.dupe(u8, "None");
     defer allocator.free(out);
     const priority = [_][]const u8{ "nvidia", "amd", "radeon", "intel", "arc", "snap", "qualcomm", "snapdragon" };
+    var priority_names: std.ArrayList(GpuNameCount) = .empty;
+    defer deinitGpuNameCounts(allocator, &priority_names);
     var lines = std.mem.splitScalar(u8, out, '\n');
     while (lines.next()) |line| {
         const lower = try std.ascii.allocLowerString(allocator, line);
@@ -389,24 +601,28 @@ fn gpuNameFromLspci(allocator: std.mem.Allocator) ![]const u8 {
         for (&priority) |vendor| {
             if (std.mem.indexOf(u8, lower, vendor) != null) {
                 if (extractPciGpuName(allocator, line)) |name| {
-                    if (!isVirtualGpuName(name)) return name;
-                    allocator.free(name);
+                    defer allocator.free(name);
+                    if (!isVirtualGpuName(name)) try appendGpuNameCount(allocator, &priority_names, name);
                 } else |_| {}
             }
         }
     }
 
+    if (priority_names.items.len != 0) return allocFormattedGpuNameCounts(allocator, priority_names.items);
+
+    var fallback_names: std.ArrayList(GpuNameCount) = .empty;
+    defer deinitGpuNameCounts(allocator, &fallback_names);
     lines = std.mem.splitScalar(u8, out, '\n');
     while (lines.next()) |line| {
         const lower = try std.ascii.allocLowerString(allocator, line);
         defer allocator.free(lower);
         if (!isDisplayPciLine(lower)) continue;
         if (extractPciGpuName(allocator, line)) |name| {
-            if (!isVirtualGpuName(name)) return name;
-            allocator.free(name);
+            defer allocator.free(name);
+            if (!isVirtualGpuName(name)) try appendGpuNameCount(allocator, &fallback_names, name);
         } else |_| {}
     }
-    return allocator.dupe(u8, "None");
+    return allocFormattedGpuNameCounts(allocator, fallback_names.items);
 }
 
 fn isDisplayPciLine(lower: []const u8) bool {
@@ -437,25 +653,67 @@ fn gpuNameFromSysfsDrm(allocator: std.mem.Allocator) ![]const u8 {
     var dir = compat.openDir("/sys/class/drm", .{ .iterate = true }) catch return allocator.dupe(u8, "None");
     defer dir.close(std.Options.debug_io);
     var it = dir.iterate();
+    var counts: std.ArrayList(GpuNameCount) = .empty;
+    defer deinitGpuNameCounts(allocator, &counts);
     while (try it.next(std.Options.debug_io)) |entry| {
         if (!std.mem.startsWith(u8, entry.name, "card")) continue;
         if (std.mem.indexOfScalar(u8, entry.name, '-') != null) continue;
         const driver = driverNameForDrmCard(allocator, entry.name) catch continue;
         defer allocator.free(driver);
         if (isExcludedDrmDriver(driver)) continue;
-        if (socModelFromCompatible(allocator, entry.name, driver)) |model| return model else |_| {}
-        if (std.mem.eql(u8, driver, "vc4") or std.mem.eql(u8, driver, "vc4-drm")) return allocator.dupe(u8, "Broadcom VideoCore IV/VI (Raspberry Pi)");
-        if (std.mem.eql(u8, driver, "v3d") or std.mem.eql(u8, driver, "v3d-drm")) return allocator.dupe(u8, "Broadcom V3D (Raspberry Pi 4/5)");
-        if (std.mem.eql(u8, driver, "msm") or std.mem.eql(u8, driver, "msm_drm")) return allocator.dupe(u8, "Qualcomm Adreno (Unknown Model)");
-        if (std.mem.eql(u8, driver, "panfrost")) return allocator.dupe(u8, "ARM Mali (Panfrost)");
-        if (std.mem.eql(u8, driver, "lima")) return allocator.dupe(u8, "ARM Mali (Lima)");
-        if (std.mem.eql(u8, driver, "sun4i-drm") or std.mem.eql(u8, driver, "sunxi-drm")) return allocator.dupe(u8, "Allwinner Display Engine");
-        if (std.mem.eql(u8, driver, "tegra")) return allocator.dupe(u8, "NVIDIA Tegra");
-        if (std.mem.eql(u8, driver, "ast")) return allocator.dupe(u8, "ASPEED Technology, Inc. ASPEED Graphics Family");
-        if (std.mem.eql(u8, driver, "i915") or std.mem.eql(u8, driver, "i915-drm")) return allocator.dupe(u8, "Intel Integrated Graphics");
-        if (std.mem.eql(u8, driver, "mgag200")) return allocator.dupe(u8, "Matrox G200 Series");
-        if (driver.len != 0) return std.fmt.allocPrint(allocator, "Direct Render Manager {s}", .{driver});
+        if (socModelFromCompatible(allocator, entry.name, driver)) |model| {
+            defer allocator.free(model);
+            try appendGpuNameCount(allocator, &counts, model);
+            continue;
+        } else |_| {}
+        if (std.mem.eql(u8, driver, "vc4") or std.mem.eql(u8, driver, "vc4-drm")) {
+            try appendGpuNameCount(allocator, &counts, "Broadcom VideoCore IV/VI (Raspberry Pi)");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "v3d") or std.mem.eql(u8, driver, "v3d-drm")) {
+            try appendGpuNameCount(allocator, &counts, "Broadcom V3D (Raspberry Pi 4/5)");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "msm") or std.mem.eql(u8, driver, "msm_drm")) {
+            try appendGpuNameCount(allocator, &counts, "Qualcomm Adreno (Unknown Model)");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "panfrost")) {
+            try appendGpuNameCount(allocator, &counts, "ARM Mali (Panfrost)");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "lima")) {
+            try appendGpuNameCount(allocator, &counts, "ARM Mali (Lima)");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "sun4i-drm") or std.mem.eql(u8, driver, "sunxi-drm")) {
+            try appendGpuNameCount(allocator, &counts, "Allwinner Display Engine");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "tegra")) {
+            try appendGpuNameCount(allocator, &counts, "NVIDIA Tegra");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "ast")) {
+            try appendGpuNameCount(allocator, &counts, "ASPEED Technology, Inc. ASPEED Graphics Family");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "i915") or std.mem.eql(u8, driver, "i915-drm")) {
+            try appendGpuNameCount(allocator, &counts, "Intel Integrated Graphics");
+            continue;
+        }
+        if (std.mem.eql(u8, driver, "mgag200")) {
+            try appendGpuNameCount(allocator, &counts, "Matrox G200 Series");
+            continue;
+        }
+        if (driver.len != 0) {
+            const name = try std.fmt.allocPrint(allocator, "Direct Render Manager {s}", .{driver});
+            defer allocator.free(name);
+            try appendGpuNameCount(allocator, &counts, name);
+        }
     }
+
+    if (counts.items.len != 0) return allocFormattedGpuNameCounts(allocator, counts.items);
 
     const model = compat.readFileAlloc(allocator, "/sys/firmware/devicetree/base/model", 4096) catch return allocator.dupe(u8, "None");
     defer allocator.free(model);

--- a/src/platform/windows.zig
+++ b/src/platform/windows.zig
@@ -8,6 +8,8 @@ const report_netstatic = @import("report_netstatic");
 var sample_mutex: compat.Mutex = .{};
 var previous_cpu: ?CpuTimes = null;
 var previous_network: ?NetworkSample = null;
+const unknown_cpu_physical_cores = std.math.maxInt(u32);
+var cached_cpu_physical_cores = std.atomic.Value(u32).init(unknown_cpu_physical_cores);
 
 const FILETIME = extern struct {
     dwLowDateTime: windows.DWORD,
@@ -283,6 +285,7 @@ pub fn basicInfo(allocator: std.mem.Allocator) !common.BasicInfo {
             .name = cpuName(allocator) catch "Unknown",
             .architecture = normalizeArch(@tagName(builtin.cpu.arch)),
             .cores = cpuCoreCount(),
+            .physical_cores = cpuPhysicalCoreCount(allocator) catch 0,
             .usage = 0.001,
         },
         .os_name = osName(allocator) catch "Microsoft Windows",
@@ -383,6 +386,37 @@ pub fn normalizeArch(arch: []const u8) []const u8 {
 
 fn cpuCoreCount() u32 {
     return @intCast(std.Thread.getCpuCount() catch 1);
+}
+
+fn cpuPhysicalCoreCount(allocator: std.mem.Allocator) !u32 {
+    const cached = cached_cpu_physical_cores.load(.acquire);
+    if (cached != unknown_cpu_physical_cores) return cached;
+
+    const output = runPowerShell(
+        allocator,
+        "Get-CimInstance Win32_Processor -ErrorAction SilentlyContinue | ForEach-Object { $_.NumberOfCores }",
+        16 * 1024,
+    ) catch {
+        cached_cpu_physical_cores.store(0, .release);
+        return 0;
+    };
+    defer allocator.free(output);
+
+    var total: u32 = 0;
+    var saw_value = false;
+    var lines = std.mem.splitScalar(u8, output, '\n');
+    while (lines.next()) |line_raw| {
+        const line = std.mem.trim(u8, line_raw, " \t\r\n");
+        if (line.len == 0) continue;
+        const value = std.fmt.parseInt(u32, line, 10) catch continue;
+        if (value == 0) continue;
+        total = total +| value;
+        saw_value = true;
+    }
+
+    const result: u32 = if (saw_value) total else 0;
+    cached_cpu_physical_cores.store(result, .release);
+    return result;
 }
 
 fn cpuName(allocator: std.mem.Allocator) ![]const u8 {
@@ -711,28 +745,60 @@ fn gpuName(allocator: std.mem.Allocator) ![]const u8 {
     );
     defer allocator.free(output);
 
-    var list: std.ArrayList([]const u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
+    var counts: std.ArrayList(GpuNameCount) = .empty;
+    defer deinitGpuNameCounts(allocator, &counts);
 
     var lines = std.mem.splitScalar(u8, output, '\n');
     while (lines.next()) |line_raw| {
-        const line = std.mem.trim(u8, line_raw, " \t\r\n");
-        if (line.len == 0) continue;
-        var seen = false;
-        for (list.items) |item| {
-            if (std.mem.eql(u8, item, line)) {
-                seen = true;
-                break;
-            }
-        }
-        if (!seen) try list.append(allocator, try allocator.dupe(u8, line));
+        try appendGpuNameCount(allocator, &counts, line_raw);
     }
 
-    if (list.items.len == 0) return allocator.dupe(u8, "None");
-    return std.mem.join(allocator, ", ", list.items);
+    return allocFormattedGpuNameCounts(allocator, counts.items);
+}
+
+const GpuNameCount = struct {
+    name: []const u8,
+    count: u32,
+};
+
+fn deinitGpuNameCounts(allocator: std.mem.Allocator, counts: *std.ArrayList(GpuNameCount)) void {
+    for (counts.items) |item| allocator.free(item.name);
+    counts.deinit(allocator);
+}
+
+fn appendGpuNameCount(allocator: std.mem.Allocator, counts: *std.ArrayList(GpuNameCount), name_raw: []const u8) !void {
+    const name = std.mem.trim(u8, name_raw, " \t\r\n");
+    if (name.len == 0 or std.mem.eql(u8, name, "None")) return;
+
+    for (counts.items) |*item| {
+        if (std.mem.eql(u8, item.name, name)) {
+            item.count = item.count +| 1;
+            return;
+        }
+    }
+
+    try counts.append(allocator, .{
+        .name = try allocator.dupe(u8, name),
+        .count = 1,
+    });
+}
+
+fn allocFormattedGpuNameCounts(allocator: std.mem.Allocator, counts: []const GpuNameCount) ![]const u8 {
+    if (counts.len == 0) return allocator.dupe(u8, "None");
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+
+    for (counts, 0..) |item, idx| {
+        if (idx != 0) try out.appendSlice(allocator, ", ");
+        if (item.count > 1) {
+            try compat.appendPrint(allocator, &out, "{s} × {d}", .{ item.name, item.count });
+        } else {
+            try compat.appendPrint(allocator, &out, "{s}", .{item.name});
+        }
+    }
+
+    return out.toOwnedSlice(allocator);
 }
 
 fn virtualization(allocator: std.mem.Allocator) ![]const u8 {

--- a/src/protocol/basic_info.zig
+++ b/src/protocol/basic_info.zig
@@ -3,14 +3,19 @@ const version = @import("../version.zig");
 const types = @import("types.zig");
 const http = @import("http.zig");
 const common = @import("../platform/common.zig");
+const v2 = @import("v2.zig");
+const v2_state = @import("v2_state.zig");
 
 /// BasicInfo payload serialization and upload helpers.
-pub fn allocBasicInfoJson(allocator: std.mem.Allocator, info: common.BasicInfo, include_kernel: bool) ![]const u8 {
+pub const BasicInfo = common.BasicInfo;
+
+pub fn allocBasicInfoJson(allocator: std.mem.Allocator, info: common.BasicInfo, include_kernel: bool, include_physical_cores: bool) ![]const u8 {
     var out = std.Io.Writer.Allocating.init(allocator);
     defer out.deinit();
     try types.writeBasicInfoJson(&out.writer, .{
         .cpu_name = info.cpu.name,
         .cpu_cores = info.cpu.cores,
+        .cpu_physical_cores = info.cpu.physical_cores,
         .arch = info.cpu.architecture,
         .os = info.os_name,
         .kernel_version = info.kernel_version,
@@ -22,18 +27,112 @@ pub fn allocBasicInfoJson(allocator: std.mem.Allocator, info: common.BasicInfo, 
         .gpu_name = info.gpu_name,
         .virtualization = info.virtualization,
         .version = version.current,
-    }, include_kernel);
+    }, include_kernel, include_physical_cores);
     return out.toOwnedSlice();
 }
 
 pub fn upload(allocator: std.mem.Allocator, cfg: anytype, info: common.BasicInfo) !void {
-    const payload = try allocBasicInfoJson(allocator, info, true);
-    defer allocator.free(payload);
+    const protocol_version = v2_state.uploadProtocolVersion();
+    if (protocol_version >= 2) {
+        try uploadV2(allocator, cfg, info, true);
+        return;
+    }
+
+    try uploadV1(allocator, cfg, info);
+}
+
+pub fn initRequestedProtocolVersionForTest(protocol_version: i32) void {
+    v2_state.initRequestedProtocolVersion(protocol_version);
+}
+
+pub fn resetConnectionProtocolVersionForTest() void {
+    v2_state.resetConnectionProtocolVersion();
+}
+
+pub fn uploadProtocolVersionForTest() i32 {
+    return v2_state.uploadProtocolVersion();
+}
+
+pub fn uploadV1(allocator: std.mem.Allocator, cfg: anytype, info: common.BasicInfo) !void {
     const url = try http.basicInfoUrl(allocator, cfg.endpoint, cfg.token);
     defer allocator.free(url);
-    http.postJson(allocator, url, payload, cfg) catch |first_err| {
-        const fallback = try allocBasicInfoJson(allocator, info, false);
+    const payload = try allocBasicInfoJson(allocator, info, true, true);
+    defer allocator.free(payload);
+    http.postJson(allocator, url, payload, cfg) catch {
+        const fallback = try allocBasicInfoJson(allocator, info, false, false);
         defer allocator.free(fallback);
-        http.postJson(allocator, url, fallback, cfg) catch return first_err;
+        try http.postJson(allocator, url, fallback, cfg);
     };
+}
+
+pub fn uploadV2(allocator: std.mem.Allocator, cfg: anytype, info: common.BasicInfo, include_physical_cores: bool) !void {
+    const url = try http.v2RpcUrl(allocator, cfg.endpoint, cfg.token);
+    defer allocator.free(url);
+    const payload = try allocBasicInfoJson(allocator, info, true, include_physical_cores);
+    defer allocator.free(payload);
+    const rpc = try v2.allocBasicInfoNotification(allocator, payload);
+    defer allocator.free(rpc);
+    const body = try maybeCompress(allocator, rpc, cfg);
+    defer allocator.free(body.body);
+    var headers = http.Headers{};
+    if (body.compressed) headers.content_encoding = "gzip";
+    const response = http.postJsonReadAuthHeaders(allocator, url, body.body, cfg, "", headers) catch |err| {
+        const attempt = v2_state.noteV2AttemptResult(2, err);
+        if (attempt.fallback) {
+            v2_state.setConnectionProtocolVersion(1);
+            try uploadV1(allocator, cfg, info);
+            return;
+        }
+        return err;
+    };
+    defer allocator.free(response);
+    if (std.mem.trim(u8, response, " \t\r\n").len != 0) {
+        var parsed = std.json.parseFromSlice(std.json.Value, allocator, response, .{}) catch |err| {
+            try handleV2UploadFailure(allocator, cfg, info, err);
+            return;
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) {
+            try handleV2UploadFailure(allocator, cfg, info, error.InvalidV2Response);
+            return;
+        }
+        const object = parsed.value.object;
+        const jsonrpc = object.get("jsonrpc") orelse {
+            try handleV2UploadFailure(allocator, cfg, info, error.InvalidV2Response);
+            return;
+        };
+        if (jsonrpc != .string or !std.mem.eql(u8, jsonrpc.string, v2.Version)) {
+            try handleV2UploadFailure(allocator, cfg, info, error.InvalidV2Response);
+            return;
+        }
+        if (object.get("error")) |err_value| {
+            if (err_value != .object) {
+                try handleV2UploadFailure(allocator, cfg, info, error.InvalidV2Response);
+                return;
+            }
+            try handleV2UploadFailure(allocator, cfg, info, error.InvalidV2Response);
+            return;
+        }
+    }
+    v2_state.resetV2ProtocolFailures(2);
+}
+
+const GzipBody = struct {
+    body: []u8,
+    compressed: bool,
+};
+
+fn maybeCompress(allocator: std.mem.Allocator, payload: []const u8, cfg: anytype) !GzipBody {
+    const result = try http.maybeGzip(allocator, payload, !cfg.disable_compression);
+    return .{ .body = result.body, .compressed = result.compressed };
+}
+
+fn handleV2UploadFailure(allocator: std.mem.Allocator, cfg: anytype, info: common.BasicInfo, err: anyerror) !void {
+    const attempt = v2_state.noteV2AttemptResult(2, err);
+    if (attempt.fallback) {
+        v2_state.setConnectionProtocolVersion(1);
+        try uploadV1(allocator, cfg, info);
+        return;
+    }
+    return err;
 }

--- a/src/protocol/http.zig
+++ b/src/protocol/http.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const flate = std.compress.flate;
 const idna = @import("idna");
 const raw_conn = @import("raw_conn.zig");
 const net = @import("net");
@@ -12,6 +13,8 @@ pub const default_timeout_ms: u64 = 30_000;
 pub const Headers = struct {
     cf_access_client_id: ?[]const u8 = null,
     cf_access_client_secret: ?[]const u8 = null,
+    authorization: ?[]const u8 = null,
+    content_encoding: ?[]const u8 = null,
 };
 
 pub const ClientOptions = struct {
@@ -165,11 +168,24 @@ pub fn postJsonRead(allocator: std.mem.Allocator, url: []const u8, payload: []co
 }
 
 pub fn postJsonReadAuth(allocator: std.mem.Allocator, url: []const u8, payload: []const u8, cfg: anytype, bearer_token: []const u8) ![]u8 {
+    return postJsonReadAuthHeaders(allocator, url, payload, cfg, bearer_token, .{});
+}
+
+pub fn postJsonReadAuthHeaders(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    payload: []const u8,
+    cfg: anytype,
+    bearer_token: []const u8,
+    extra_headers: Headers,
+) ![]u8 {
     const ascii_url = try idna.convertUrlToAscii(allocator, url);
     defer allocator.free(ascii_url);
     const authorization = if (bearer_token.len == 0) "" else try std.fmt.allocPrint(allocator, "Bearer {s}", .{bearer_token});
     defer if (bearer_token.len != 0) allocator.free(authorization);
-    return requestReadAuth(allocator, ascii_url, "POST", payload, "application/json", cfg, authorization);
+    var headers = extra_headers;
+    if (authorization.len != 0) headers.authorization = authorization;
+    return requestReadWithFamilyHeaders(allocator, ascii_url, "POST", payload, "application/json", cfg, dashboardAddressFamily(cfg), "komari-zig-agent", headers);
 }
 
 pub fn getRead(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
@@ -226,6 +242,12 @@ pub fn basicInfoUrl(allocator: std.mem.Allocator, endpoint: []const u8, token: [
     return idna.convertUrlToAscii(allocator, raw);
 }
 
+pub fn v2RpcUrl(allocator: std.mem.Allocator, endpoint: []const u8, token: []const u8) ![]const u8 {
+    const raw = try std.fmt.allocPrint(allocator, "{s}/api/clients/v2/rpc?token={s}", .{ trimEndpoint(endpoint), token });
+    defer allocator.free(raw);
+    return idna.convertUrlToAscii(allocator, raw);
+}
+
 pub fn taskResultUrl(allocator: std.mem.Allocator, endpoint: []const u8, token: []const u8) ![]const u8 {
     const raw = try std.fmt.allocPrint(allocator, "{s}/api/clients/task/result?token={s}", .{ trimEndpoint(endpoint), token });
     defer allocator.free(raw);
@@ -241,9 +263,16 @@ pub fn registerUrl(allocator: std.mem.Allocator, endpoint: []const u8, hostname:
 }
 
 pub fn reportWsUrl(allocator: std.mem.Allocator, endpoint: []const u8, token: []const u8) ![]const u8 {
+    return reportWsUrlForProtocol(allocator, endpoint, token, 1);
+}
+
+pub fn reportWsUrlForProtocol(allocator: std.mem.Allocator, endpoint: []const u8, token: []const u8, protocol_version: i32) ![]const u8 {
     const base = try wsEndpoint(allocator, endpoint);
     defer allocator.free(base);
-    const raw = try std.fmt.allocPrint(allocator, "{s}/api/clients/report?token={s}", .{ trimEndpoint(base), token });
+    const raw = if (protocol_version >= 2)
+        try std.fmt.allocPrint(allocator, "{s}/api/clients/v2/rpc?token={s}", .{ trimEndpoint(base), token })
+    else
+        try std.fmt.allocPrint(allocator, "{s}/api/clients/report?token={s}", .{ trimEndpoint(base), token });
     defer allocator.free(raw);
     return idna.convertUrlToAscii(allocator, raw);
 }
@@ -283,6 +312,27 @@ fn postHeaders(cfg: anytype, authorization: []const u8, out: *[3]std.http.Header
         len += 1;
     }
     return out[0..len];
+}
+
+pub fn dashboardAddressFamily(cfg: anytype) raw_conn.AddressFamily {
+    if (@hasField(@TypeOf(cfg), "prefer_ip_version")) {
+        const prefer = @field(cfg, "prefer_ip_version");
+        if (std.mem.eql(u8, prefer, "4")) return .ipv4;
+        if (std.mem.eql(u8, prefer, "6")) return .ipv6;
+    }
+    return .any;
+}
+
+pub fn maybeGzip(allocator: std.mem.Allocator, payload: []const u8, enabled: bool) !struct { body: []u8, compressed: bool } {
+    if (!enabled or payload.len == 0) return .{ .body = try allocator.dupe(u8, payload), .compressed = false };
+
+    var out = try std.Io.Writer.Allocating.initCapacity(allocator, payload.len + 64);
+    errdefer out.deinit();
+    var deflate_buf: [flate.max_window_len * 2]u8 = undefined;
+    var gzip = try flate.Compress.init(&out.writer, deflate_buf[0..], .gzip, .default);
+    try gzip.writer.writeAll(payload);
+    try gzip.finish();
+    return .{ .body = try out.toOwnedSlice(), .compressed = true };
 }
 
 fn wsEndpoint(allocator: std.mem.Allocator, endpoint: []const u8) ![]const u8 {
@@ -390,12 +440,26 @@ fn requestReadWithFamily(allocator: std.mem.Allocator, url: []const u8, method: 
 }
 
 fn requestReadWithFamilyAuth(allocator: std.mem.Allocator, url: []const u8, method: []const u8, payload: []const u8, content_type: []const u8, cfg: anytype, family: raw_conn.AddressFamily, user_agent: []const u8, authorization: []const u8) ![]u8 {
+    return requestReadWithFamilyHeaders(allocator, url, method, payload, content_type, cfg, family, user_agent, .{ .authorization = if (authorization.len == 0) null else authorization });
+}
+
+fn requestReadWithFamilyHeaders(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    method: []const u8,
+    payload: []const u8,
+    content_type: []const u8,
+    cfg: anytype,
+    family: raw_conn.AddressFamily,
+    user_agent: []const u8,
+    headers: Headers,
+) ![]u8 {
     var current_url: []const u8 = try allocator.dupe(u8, url);
     defer allocator.free(current_url);
     var redirects: u32 = 0;
     const timeout_ms = timeoutMsForConfig(cfg);
     while (true) {
-        var response = try requestReadWithFamilyAuthOnce(allocator, current_url, method, payload, content_type, cfg, family, user_agent, authorization, timeout_ms);
+        var response = try requestReadWithFamilyHeadersOnce(allocator, current_url, method, payload, content_type, cfg, family, user_agent, headers, timeout_ms);
         errdefer response.deinit(allocator);
         if (response.status == 200) return response.body;
         if (isRedirectStatus(response.status)) {
@@ -413,7 +477,18 @@ fn requestReadWithFamilyAuth(allocator: std.mem.Allocator, url: []const u8, meth
     }
 }
 
-fn requestReadWithFamilyAuthOnce(allocator: std.mem.Allocator, url: []const u8, method: []const u8, payload: []const u8, content_type: []const u8, cfg: anytype, family: raw_conn.AddressFamily, user_agent: []const u8, authorization: []const u8, timeout_ms: u64) !HttpResponse {
+fn requestReadWithFamilyHeadersOnce(
+    allocator: std.mem.Allocator,
+    url: []const u8,
+    method: []const u8,
+    payload: []const u8,
+    content_type: []const u8,
+    cfg: anytype,
+    family: raw_conn.AddressFamily,
+    user_agent: []const u8,
+    headers: Headers,
+    timeout_ms: u64,
+) !HttpResponse {
     const uri = try std.Uri.parse(url);
     const host = try uriHost(allocator, uri);
     defer allocator.free(host);
@@ -444,7 +519,8 @@ fn requestReadWithFamilyAuthOnce(allocator: std.mem.Allocator, url: []const u8, 
         }
         var cf: [2]std.http.Header = undefined;
         for (cloudflareHeaders(cfg, &cf)) |header| try req.writer.print("{s}: {s}\r\n", .{ header.name, header.value });
-        if (authorization.len != 0) try req.writer.print("Authorization: {s}\r\n", .{authorization});
+        if (headers.authorization) |authorization| try req.writer.print("Authorization: {s}\r\n", .{authorization});
+        if (headers.content_encoding) |content_encoding| try req.writer.print("Content-Encoding: {s}\r\n", .{content_encoding});
         try req.writer.writeAll("\r\n");
         if (payload.len != 0) try req.writer.writeAll(payload);
         const request = try req.toOwnedSlice();

--- a/src/protocol/report_ws.zig
+++ b/src/protocol/report_ws.zig
@@ -9,6 +9,8 @@ const ping = @import("ping.zig");
 const task = @import("task.zig");
 const terminal = @import("../terminal/terminal.zig");
 const update = @import("../update.zig");
+const v2 = @import("v2.zig");
+const v2_state = @import("v2_state.zig");
 const ws_client = @import("ws_client.zig");
 const compat = @import("compat");
 const timing = @import("report_timing.zig");
@@ -21,6 +23,10 @@ pub const ServerMessage = ws_message.ServerMessage;
 pub const parseServerMessage = ws_message.parseServerMessage;
 
 const report_stack_buffer_size = 4096;
+
+var v2_ack_mutex: compat.Mutex = .{};
+var v2_ack_event_ids: std.ArrayList([]const u8) = .empty;
+var v2_seen_event_ids: std.ArrayList([]const u8) = .empty;
 
 fn snapshotOptions(cfg: config.Config) common.SnapshotOptions {
     return .{
@@ -39,11 +45,50 @@ pub fn runOnce(allocator: std.mem.Allocator, cfg: config.Config) ![]const u8 {
     return report.allocReportJson(allocator, try provider.snapshotWithOptions(snapshotOptions(cfg)));
 }
 
+pub fn processV2ResponseBodyForTest(allocator: std.mem.Allocator, cfg: config.Config, body: []const u8) !void {
+    return processV2ResponseBody(allocator, cfg, body);
+}
+
+pub fn postV2PullOnceForTest(allocator: std.mem.Allocator, cfg: config.Config) !void {
+    return postV2PullOnce(allocator, cfg);
+}
+
+pub fn postV2ReportPayloadForTest(allocator: std.mem.Allocator, cfg: config.Config, report_json: []const u8) !void {
+    const ack_ids = try snapshotV2AckEventIDs(allocator);
+    defer allocator.free(ack_ids);
+    const request_id = try std.fmt.allocPrint(allocator, "report-{d}", .{compat.nanoTimestamp()});
+    defer allocator.free(request_id);
+    const request = try v2.allocReportRequest(allocator, request_id, report_json, ack_ids);
+    defer allocator.free(request);
+    const body = try postV2Request(allocator, cfg, request);
+    defer allocator.free(body);
+    clearV2AckEventIDs(ack_ids);
+    try processV2ResponseBody(allocator, cfg, body);
+    v2_state.resetV2ProtocolFailures(2);
+}
+
+pub fn snapshotV2AckEventIDsForTest(allocator: std.mem.Allocator) ![]const []const u8 {
+    return snapshotV2AckEventIDs(allocator);
+}
+
+pub fn resetV2ResponseTrackingForTest() void {
+    resetV2ResponseTracking();
+}
+
+pub fn initRequestedProtocolVersionForTest(version: i32) void {
+    v2_state.initRequestedProtocolVersion(version);
+}
+
+pub fn resetConnectionProtocolVersionForTest() void {
+    v2_state.resetConnectionProtocolVersion();
+}
+
 fn writeReportOnce(allocator: std.mem.Allocator, ws: *ws_client.Client, cfg: config.Config) !void {
     const snap = try provider.snapshotWithOptions(snapshotOptions(cfg));
     var owns_gpu_json = true;
     defer if (owns_gpu_json and snap.gpu_json.len != 0) std.heap.page_allocator.free(snap.gpu_json);
 
+    const protocol_version = v2_state.uploadProtocolVersion();
     var buf: [report_stack_buffer_size]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buf);
     report.writeReportJson(&writer, snap) catch |err| switch (err) {
@@ -51,11 +96,23 @@ fn writeReportOnce(allocator: std.mem.Allocator, ws: *ws_client.Client, cfg: con
             owns_gpu_json = false;
             const payload = try report.allocReportJson(allocator, snap);
             defer allocator.free(payload);
-            try ws.writeText(payload);
+            if (protocol_version >= 2) {
+                const rpc = try v2.allocReportNotification(allocator, payload);
+                defer allocator.free(rpc);
+                try ws.writeText(rpc);
+            } else {
+                try ws.writeText(payload);
+            }
             return;
         },
     };
-    try ws.writeText(writer.buffered());
+    if (protocol_version >= 2) {
+        const rpc = try v2.allocReportNotification(allocator, writer.buffered());
+        defer allocator.free(rpc);
+        try ws.writeText(rpc);
+    } else {
+        try ws.writeText(writer.buffered());
+    }
 }
 
 pub const reportIntervalMs = timing.reportIntervalMs;
@@ -71,7 +128,18 @@ pub fn loop(allocator: std.mem.Allocator, cfg: config.Config, stop_requested: ?*
     defer stdout.flush() catch {};
     var update_confirmed = false;
     while (!isStopRequested(stop_requested)) {
-        var ws = connectReportWsWithRetries(allocator, cfg, stop_requested) catch |err| {
+        var ws = connectReportWsWithRetries(allocator, cfg, stop_requested) catch |err| blk: {
+            if (v2_state.requestedProtocolVersion() >= 2 and v2_state.uploadProtocolVersion() >= 2) {
+                const fallback_ws = runPostFallback(allocator, cfg, stop_requested) catch |fallback_err| {
+                    if (isStopRequested(stop_requested)) return;
+                    try stdout.print("WebSocket POST fallback failed: {s}\n", .{@errorName(fallback_err)});
+                    return fallback_err;
+                };
+                if (fallback_ws == null) {
+                    return error.ShutdownRequested;
+                }
+                break :blk fallback_ws.?;
+            }
             if (isStopRequested(stop_requested)) return;
             try stdout.print("WebSocket connect failed: {s}\n", .{@errorName(err)});
             return err;
@@ -87,6 +155,7 @@ pub fn loop(allocator: std.mem.Allocator, cfg: config.Config, stop_requested: ?*
                 ws.writePing() catch |err| {
                     try stdout.print("Failed to send heartbeat: {s}\n", .{@errorName(err)});
                     ws.close(allocator);
+                    v2_state.resetConnectionProtocolVersion();
                     closed = true;
                     break;
                 };
@@ -95,6 +164,7 @@ pub fn loop(allocator: std.mem.Allocator, cfg: config.Config, stop_requested: ?*
             writeReportOnce(allocator, ws, cfg) catch |err| {
                 try stdout.print("WebSocket write failed: {s}\n", .{@errorName(err)});
                 ws.close(allocator);
+                v2_state.resetConnectionProtocolVersion();
                 closed = true;
                 break;
             };
@@ -136,9 +206,63 @@ fn sleepOrStopMs(milliseconds: u64, stop_requested: ?*const std.atomic.Value(boo
 }
 
 fn connectReportWs(allocator: std.mem.Allocator, cfg: config.Config) !*ws_client.Client {
-    const url = try http.reportWsUrl(allocator, cfg.endpoint, cfg.token);
+    const protocol_version = v2_state.uploadProtocolVersion();
+    const url = try http.reportWsUrlForProtocol(allocator, cfg.endpoint, cfg.token, protocol_version);
     defer allocator.free(url);
-    return ws_client.connect(allocator, url, cfg);
+    const ws = ws_client.connect(allocator, url, cfg) catch |err| {
+        const attempt = v2_state.noteV2AttemptResult(protocol_version, err);
+        if (attempt.fallback) {
+            v2_state.setConnectionProtocolVersion(1);
+            const fallback_url = try http.reportWsUrlForProtocol(allocator, cfg.endpoint, cfg.token, 1);
+            defer allocator.free(fallback_url);
+            const fallback_ws = try ws_client.connect(allocator, fallback_url, cfg);
+            v2_state.setConnectionProtocolVersion(1);
+            v2_state.resetV2ProtocolFailures(1);
+            return fallback_ws;
+        }
+        return err;
+    };
+    v2_state.setConnectionProtocolVersion(protocol_version);
+    v2_state.resetV2ProtocolFailures(protocol_version);
+    return ws;
+}
+
+fn runPostFallback(allocator: std.mem.Allocator, cfg: config.Config, stop_requested: ?*const std.atomic.Value(bool)) !?*ws_client.Client {
+    const report_interval_ms = reportIntervalMs(cfg.interval);
+    const pull_interval_ms = std.time.ms_per_s;
+    const reconnect_interval_ms = @as(u64, @intCast(reconnectSleepSeconds(cfg.reconnect_interval))) * std.time.ms_per_s;
+    var last_report_ms = compat.milliTimestamp();
+    var last_pull_ms = compat.milliTimestamp() - @as(i64, @intCast(pull_interval_ms));
+    var last_reconnect_ms = compat.milliTimestamp() - @as(i64, @intCast(reconnect_interval_ms));
+
+    while (!isStopRequested(stop_requested)) {
+        const now_ms = compat.milliTimestamp();
+        if (@as(u64, @intCast(@max(now_ms - last_report_ms, 0))) >= report_interval_ms) {
+            last_report_ms = now_ms;
+            postV2ReportOnce(allocator, cfg) catch |err| {
+                if (v2_state.noteV2AttemptResult(2, err).fallback) {
+                    v2_state.setConnectionProtocolVersion(1);
+                    return err;
+                }
+            };
+        }
+        if (@as(u64, @intCast(@max(now_ms - last_pull_ms, 0))) >= pull_interval_ms) {
+            last_pull_ms = now_ms;
+            postV2PullOnce(allocator, cfg) catch |err| {
+                if (v2_state.noteV2AttemptResult(2, err).fallback) {
+                    v2_state.setConnectionProtocolVersion(1);
+                    return err;
+                }
+            };
+        }
+        if (@as(u64, @intCast(@max(now_ms - last_reconnect_ms, 0))) >= reconnect_interval_ms) {
+            last_reconnect_ms = now_ms;
+            const ws = connectReportWs(allocator, cfg) catch continue;
+            return ws;
+        }
+        compat.sleep(100 * std.time.ns_per_ms);
+    }
+    return null;
 }
 
 fn connectReportWsWithRetries(allocator: std.mem.Allocator, cfg: config.Config, stop_requested: ?*const std.atomic.Value(bool)) !*ws_client.Client {
@@ -152,6 +276,7 @@ fn connectReportWsWithRetries(allocator: std.mem.Allocator, cfg: config.Config, 
             if (sleepOrStop(reconnectSleepSeconds(cfg.reconnect_interval), stop_requested)) return error.ShutdownRequested;
             continue;
         };
+        v2_state.resetV2ProtocolFailures(v2_state.uploadProtocolVersion());
         debug.log("report websocket connected on attempt {d}", .{retry + 1});
         return ws;
     }
@@ -195,7 +320,7 @@ fn readerLoop(allocator: std.mem.Allocator, conn: *ws_client.Client, cfg: config
 fn handleServerMessage(allocator: std.mem.Allocator, conn: *ws_client.Client, cfg: config.Config, msg: ServerMessage) !void {
     switch (msg.kind) {
         .ping => {
-            const args = try PingTaskArgs.init(allocator, conn, cfg, msg);
+            const args = try PingTaskArgs.init(allocator, conn, cfg, v2_state.uploadProtocolVersion(), msg);
             errdefer args.deinit(allocator);
             const thread = try std.Thread.spawn(.{ .stack_size = thread_stacks.tls_worker_stack_size }, runPingTask, .{ allocator, args });
             thread.detach();
@@ -212,6 +337,7 @@ fn handleServerMessage(allocator: std.mem.Allocator, conn: *ws_client.Client, cf
             const thread = try std.Thread.spawn(.{ .stack_size = thread_stacks.terminal_worker_stack_size }, runTerminalTask, .{ allocator, args });
             thread.detach();
         },
+        .message, .event => {},
         .unknown => {},
     }
 }
@@ -243,17 +369,19 @@ fn runTerminalTask(allocator: std.mem.Allocator, args: TerminalTaskArgs) void {
 }
 
 const PingTaskArgs = struct {
-    conn: *ws_client.Client,
+    conn: ?*ws_client.Client,
     cfg: config.Config,
+    protocol_version: i32,
     ping_task_id: u64,
     ping_type: []const u8,
     ping_target: []const u8,
 
-    fn init(allocator: std.mem.Allocator, conn: *ws_client.Client, cfg: config.Config, msg: ServerMessage) !PingTaskArgs {
-        conn.acquire();
+    fn init(allocator: std.mem.Allocator, conn: ?*ws_client.Client, cfg: config.Config, protocol_version: i32, msg: ServerMessage) !PingTaskArgs {
+        if (conn) |ws| ws.acquire();
         return .{
             .conn = conn,
             .cfg = cfg,
+            .protocol_version = protocol_version,
             .ping_task_id = msg.ping_task_id,
             .ping_type = try allocator.dupe(u8, msg.ping_type),
             .ping_target = try allocator.dupe(u8, msg.ping_target),
@@ -263,7 +391,7 @@ const PingTaskArgs = struct {
     fn deinit(self: PingTaskArgs, allocator: std.mem.Allocator) void {
         allocator.free(self.ping_type);
         allocator.free(self.ping_target);
-        self.conn.release(allocator);
+        if (self.conn) |conn| conn.release(allocator);
     }
 };
 
@@ -272,9 +400,18 @@ fn runPingTask(allocator: std.mem.Allocator, args: PingTaskArgs) void {
     const value = ping.measure(allocator, args.ping_type, args.ping_target, args.cfg.custom_dns);
     const finished = task.utcNow(allocator) catch return;
     defer allocator.free(finished);
-    const payload = ping.allocPingResultJson(allocator, args.ping_task_id, args.ping_type, value, finished) catch return;
+    const payload = if (args.protocol_version >= 2)
+        v2.allocPingResultNotification(allocator, args.ping_task_id, args.ping_type, value, finished) catch return
+    else
+        ping.allocPingResultJson(allocator, args.ping_task_id, args.ping_type, value, finished) catch return;
     defer allocator.free(payload);
-    args.conn.writeText(payload) catch {};
+    if (args.conn) |conn| {
+        conn.writeText(payload) catch {};
+        return;
+    }
+    if (args.protocol_version >= 2) {
+        postV2Payload(allocator, args.cfg, payload) catch {};
+    }
 }
 
 const ExecTaskArgs = struct {
@@ -298,5 +435,255 @@ const ExecTaskArgs = struct {
 
 fn runExecTask(allocator: std.mem.Allocator, args: ExecTaskArgs) void {
     defer args.deinit(allocator);
-    task.uploadExecResult(allocator, args.cfg, args.task_id, args.command) catch {};
+    task.uploadExecResult(allocator, args.cfg, v2_state.uploadProtocolVersion(), args.task_id, args.command) catch {};
+}
+
+fn postV2ReportOnce(allocator: std.mem.Allocator, cfg: config.Config) !void {
+    const snap = try provider.snapshotWithOptions(snapshotOptions(cfg));
+    const payload = try report.allocReportJson(allocator, snap);
+    defer allocator.free(payload);
+    const ack_ids = try snapshotV2AckEventIDs(allocator);
+    defer allocator.free(ack_ids);
+    const request_id = try std.fmt.allocPrint(allocator, "report-{d}", .{compat.nanoTimestamp()});
+    defer allocator.free(request_id);
+    const request = try v2.allocReportRequest(allocator, request_id, payload, ack_ids);
+    defer allocator.free(request);
+    const body = try postV2Request(allocator, cfg, request);
+    defer allocator.free(body);
+    clearV2AckEventIDs(ack_ids);
+    try processV2ResponseBody(allocator, cfg, body);
+    v2_state.resetV2ProtocolFailures(2);
+}
+
+fn postV2PullOnce(allocator: std.mem.Allocator, cfg: config.Config) !void {
+    const ack_ids = try snapshotV2AckEventIDs(allocator);
+    defer allocator.free(ack_ids);
+    const request_id = try std.fmt.allocPrint(allocator, "pull-{d}", .{compat.nanoTimestamp()});
+    defer allocator.free(request_id);
+    const request = try v2.allocPullRequest(allocator, request_id, .{
+        .capabilities = &.{ "exec", "ping", "message", "event", "terminal" },
+        .ack_event_ids = ack_ids,
+    });
+    defer allocator.free(request);
+    const body = try postV2Request(allocator, cfg, request);
+    defer allocator.free(body);
+    clearV2AckEventIDs(ack_ids);
+    try processV2ResponseBody(allocator, cfg, body);
+    v2_state.resetV2ProtocolFailures(2);
+}
+
+fn postV2Payload(allocator: std.mem.Allocator, cfg: config.Config, payload: []const u8) !void {
+    const body = try http.maybeGzip(allocator, payload, !cfg.disable_compression);
+    defer allocator.free(body.body);
+    var headers = http.Headers{};
+    if (body.compressed) headers.content_encoding = "gzip";
+    const url = try http.v2RpcUrl(allocator, cfg.endpoint, cfg.token);
+    defer allocator.free(url);
+    _ = try http.postJsonReadAuthHeaders(allocator, url, body.body, cfg, "", headers);
+}
+
+fn postV2Request(allocator: std.mem.Allocator, cfg: config.Config, payload: []const u8) ![]u8 {
+    const body = try http.maybeGzip(allocator, payload, !cfg.disable_compression);
+    defer allocator.free(body.body);
+    var headers = http.Headers{};
+    if (body.compressed) headers.content_encoding = "gzip";
+    const url = try http.v2RpcUrl(allocator, cfg.endpoint, cfg.token);
+    defer allocator.free(url);
+    return http.postJsonReadAuthHeaders(allocator, url, body.body, cfg, "", headers);
+}
+
+fn processV2ResponseBody(allocator: std.mem.Allocator, cfg: config.Config, body: []const u8) !void {
+    if (body.len == 0) return;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidV2Response;
+    const object = parsed.value.object;
+    const jsonrpc = object.get("jsonrpc") orelse return error.InvalidV2Response;
+    if (jsonrpc != .string or !std.mem.eql(u8, jsonrpc.string, v2.Version)) return error.InvalidV2Response;
+    if (object.get("error")) |err_value| {
+        if (err_value != .object) return error.InvalidV2Response;
+        return error.InvalidV2Response;
+    }
+    if (object.get("result")) |result_value| {
+        if (result_value != .object) return error.InvalidV2EventResult;
+        const result = result_value.object;
+        if (result.get("events")) |events_value| {
+            if (events_value != .array) return error.InvalidV2EventResult;
+            for (events_value.array.items) |item| {
+                if (item != .object) continue;
+                const event = item.object;
+                const event_id = if (event.get("id")) |id_value| if (id_value == .string) id_value.string else "" else "";
+                const method = if (event.get("method")) |method_value| if (method_value == .string) method_value.string else "" else "";
+                const params = event.get("params");
+                if (processV2Event(allocator, null, cfg, method, params, event_id)) {
+                    try addV2AckEventID(allocator, event_id);
+                }
+            }
+        }
+    }
+    v2_state.resetV2ProtocolFailures(2);
+}
+
+fn processV2Event(allocator: std.mem.Allocator, conn: ?*ws_client.Client, cfg: config.Config, method: []const u8, params: ?std.json.Value, event_id: []const u8) bool {
+    if (event_id.len != 0 and !markV2EventSeen(event_id)) return true;
+    if (method.len == 0) return false;
+    if (std.mem.eql(u8, method, v2.MethodAgentExec)) {
+        const p = parseV2ExecParams(allocator, params) catch return false;
+        const args = ExecTaskArgs{ .cfg = cfg, .task_id = p.task_id, .command = p.command };
+        const thread = std.Thread.spawn(.{}, runExecTask, .{ allocator, args }) catch {
+            args.deinit(allocator);
+            return false;
+        };
+        thread.detach();
+        return true;
+    }
+    if (std.mem.eql(u8, method, v2.MethodAgentPing)) {
+        const p = parseV2PingParams(allocator, params) catch return false;
+        if (conn) |ws| ws.acquire();
+        const args = PingTaskArgs{
+            .conn = conn,
+            .cfg = cfg,
+            .protocol_version = 2,
+            .ping_task_id = p.ping_task_id,
+            .ping_type = p.ping_type,
+            .ping_target = p.ping_target,
+        };
+        const thread = std.Thread.spawn(.{ .stack_size = thread_stacks.tls_worker_stack_size }, runPingTask, .{ allocator, args }) catch {
+            args.deinit(allocator);
+            return false;
+        };
+        thread.detach();
+        return true;
+    }
+    if (std.mem.eql(u8, method, v2.MethodAgentTerminal)) {
+        const request_id = parseV2TerminalRequestId(allocator, params) catch return false;
+        const args = TerminalTaskArgs{ .cfg = cfg, .request_id = request_id };
+        const thread = std.Thread.spawn(.{ .stack_size = thread_stacks.terminal_worker_stack_size }, runTerminalTask, .{ allocator, args }) catch {
+            args.deinit(allocator);
+            return false;
+        };
+        thread.detach();
+        return true;
+    }
+    if (std.mem.eql(u8, method, v2.MethodAgentMessage) or std.mem.eql(u8, method, v2.MethodAgentEvent)) {
+        return true;
+    }
+    return false;
+}
+
+fn parseV2ExecParams(allocator: std.mem.Allocator, params: ?std.json.Value) !struct { task_id: []const u8, command: []const u8 } {
+    const object = try expectV2Object(params);
+    return .{
+        .task_id = try dupJsonString(allocator, object, "task_id"),
+        .command = try dupJsonString(allocator, object, "command"),
+    };
+}
+
+fn parseV2PingParams(allocator: std.mem.Allocator, params: ?std.json.Value) !struct { ping_task_id: u64, ping_type: []const u8, ping_target: []const u8 } {
+    const object = try expectV2Object(params);
+    return .{
+        .ping_task_id = jsonInt(object, "ping_task_id"),
+        .ping_type = try dupJsonString(allocator, object, "ping_type"),
+        .ping_target = try dupJsonString(allocator, object, "ping_target"),
+    };
+}
+
+fn parseV2TerminalRequestId(allocator: std.mem.Allocator, params: ?std.json.Value) ![]const u8 {
+    const object = try expectV2Object(params);
+    return dupJsonString(allocator, object, "request_id");
+}
+
+fn expectV2Object(params: ?std.json.Value) !std.json.ObjectMap {
+    const value = params orelse return error.InvalidV2EventResult;
+    if (value != .object) return error.InvalidV2EventResult;
+    return value.object;
+}
+
+fn dupJsonString(allocator: std.mem.Allocator, object: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    if (object.get(key)) |value| {
+        if (value == .string) return allocator.dupe(u8, value.string);
+    }
+    return allocator.dupe(u8, "");
+}
+
+fn jsonInt(object: std.json.ObjectMap, key: []const u8) u64 {
+    if (object.get(key)) |value| {
+        return switch (value) {
+            .integer => |n| @intCast(n),
+            .string => |text| std.fmt.parseInt(u64, text, 10) catch 0,
+            else => 0,
+        };
+    }
+    return 0;
+}
+
+fn snapshotV2AckEventIDs(allocator: std.mem.Allocator) ![]const []const u8 {
+    v2_ack_mutex.lock();
+    defer v2_ack_mutex.unlock();
+    var out: std.ArrayList([]const u8) = .empty;
+    for (v2_ack_event_ids.items) |item| try out.append(allocator, item);
+    return out.toOwnedSlice(allocator);
+}
+
+fn clearV2AckEventIDs(sent: []const []const u8) void {
+    if (sent.len == 0) return;
+    v2_ack_mutex.lock();
+    defer v2_ack_mutex.unlock();
+    var removed: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (removed.items) |item| std.heap.page_allocator.free(item);
+        removed.deinit(std.heap.page_allocator);
+    }
+    var i: usize = 0;
+    while (i < v2_ack_event_ids.items.len) {
+        const current = v2_ack_event_ids.items[i];
+        var matched = false;
+        for (sent) |value| {
+            if (std.mem.eql(u8, current, value)) {
+                matched = true;
+                break;
+            }
+        }
+        if (matched) {
+            removed.append(std.heap.page_allocator, current) catch {};
+            _ = v2_ack_event_ids.orderedRemove(i);
+            continue;
+        }
+        i += 1;
+    }
+}
+
+fn addV2AckEventID(allocator: std.mem.Allocator, id: []const u8) !void {
+    _ = allocator;
+    if (id.len == 0) return;
+    v2_ack_mutex.lock();
+    defer v2_ack_mutex.unlock();
+    for (v2_ack_event_ids.items) |item| {
+        if (std.mem.eql(u8, item, id)) return;
+    }
+    try v2_ack_event_ids.append(std.heap.page_allocator, try std.heap.page_allocator.dupe(u8, id));
+}
+
+fn markV2EventSeen(id: []const u8) bool {
+    if (id.len == 0) return true;
+    v2_ack_mutex.lock();
+    defer v2_ack_mutex.unlock();
+    for (v2_seen_event_ids.items) |item| {
+        if (std.mem.eql(u8, item, id)) return false;
+    }
+    const dup = std.heap.page_allocator.dupe(u8, id) catch return true;
+    v2_seen_event_ids.append(std.heap.page_allocator, dup) catch {
+        std.heap.page_allocator.free(dup);
+        return true;
+    };
+    return true;
+}
+
+fn resetV2ResponseTracking() void {
+    v2_ack_mutex.lock();
+    defer v2_ack_mutex.unlock();
+    for (v2_ack_event_ids.items) |item| std.heap.page_allocator.free(item);
+    v2_ack_event_ids.clearRetainingCapacity();
+    for (v2_seen_event_ids.items) |item| std.heap.page_allocator.free(item);
+    v2_seen_event_ids.clearRetainingCapacity();
 }

--- a/src/protocol/task.zig
+++ b/src/protocol/task.zig
@@ -61,14 +61,13 @@ pub fn runCommandDetailed(allocator: std.mem.Allocator, command: []const u8) !Co
 
 fn runCommandDetailedWindows(allocator: std.mem.Allocator, command: []const u8) !CommandResult {
     const work_allocator = std.heap.page_allocator;
-    const wrapped = try std.fmt.allocPrint(
-        work_allocator,
-        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; & {{ {s} }} 2>&1; $code = if ($null -ne $LASTEXITCODE) {{ [int]$LASTEXITCODE }} elseif ($?) {{ 0 }} else {{ 1 }}; exit $code",
-        .{command},
-    );
-    defer work_allocator.free(wrapped);
+    const script_path = try createWindowsTaskScript(work_allocator, command);
+    defer {
+        compat.deleteFileAbsolute(script_path) catch {};
+        work_allocator.free(script_path);
+    }
 
-    const result = try compat.runOutputWindows(work_allocator, &.{ "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", wrapped }, max_command_output_bytes);
+    const result = try compat.runOutputWindows(work_allocator, &.{ "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script_path }, max_command_output_bytes);
     defer work_allocator.free(result.stdout);
 
     return .{
@@ -78,29 +77,41 @@ fn runCommandDetailedWindows(allocator: std.mem.Allocator, command: []const u8) 
 }
 
 fn runCommandDetailedPosix(allocator: std.mem.Allocator, command: []const u8) !CommandResult {
-    const shell_command_raw = try std.fmt.allocPrint(allocator, "PATH={s}; export PATH; exec 2>&1; {s}", .{ safe_command_path, command });
-    defer allocator.free(shell_command_raw);
-    const shell_command = try allocator.dupeZ(u8, shell_command_raw);
-    defer allocator.free(shell_command);
     const fds = try compat.pipe();
     errdefer {
         compat.closeFd(fds[0]);
         compat.closeFd(fds[1]);
     }
+    const stdin_fds = try compat.pipe();
+    errdefer {
+        compat.closeFd(stdin_fds[0]);
+        compat.closeFd(stdin_fds[1]);
+    }
     const pid = try compat.fork();
     if (pid == 0) {
         compat.closeFd(fds[0]);
+        compat.closeFd(stdin_fds[1]);
+        compat.dup2(stdin_fds[0], 0) catch std.process.exit(127);
         compat.dup2(fds[1], 1) catch std.process.exit(127);
         compat.dup2(fds[1], 2) catch std.process.exit(127);
+        compat.closeFd(stdin_fds[0]);
         compat.closeFd(fds[1]);
         const shell: [:0]const u8 = "/bin/sh";
-        const arg_c: [:0]const u8 = "-c";
         const env_path: [:0]const u8 = "PATH=" ++ safe_command_path;
-        const argv = [_:null]?[*:0]const u8{ shell.ptr, arg_c.ptr, shell_command.ptr };
+        const arg_s: [:0]const u8 = "-s";
+        const argv = [_:null]?[*:0]const u8{ shell.ptr, arg_s.ptr };
         const envp = [_:null]?[*:0]const u8{env_path.ptr};
         compat.execveZ(shell.ptr, &argv, &envp) catch std.process.exit(127);
     }
+    compat.closeFd(stdin_fds[0]);
     compat.closeFd(fds[1]);
+    const stdin_payload = try std.fmt.allocPrint(allocator, "PATH={s}; export PATH\n{s}\n", .{ safe_command_path, command });
+    defer allocator.free(stdin_payload);
+    writeAllFd(stdin_fds[1], stdin_payload) catch |err| {
+        compat.closeFd(stdin_fds[1]);
+        return err;
+    };
+    compat.closeFd(stdin_fds[1]);
     var out = std.Io.Writer.Allocating.init(allocator);
     errdefer out.deinit();
     var total: usize = 0;
@@ -126,9 +137,9 @@ pub const CommandRunner = *const fn (std.mem.Allocator, *std.process.Environ.Map
 
 fn realCommandRunner(allocator: std.mem.Allocator, env: *std.process.Environ.Map, command: []const u8) !std.process.RunResult {
     const work_allocator = std.heap.smp_allocator;
-    const merged_command = try std.fmt.allocPrint(work_allocator, "exec 2>&1; {s}", .{command});
-    defer work_allocator.free(merged_command);
-    const output = try compat.runOutputIgnoreStderr(work_allocator, &.{ "/bin/sh", "-c", merged_command }, env, max_command_output_bytes);
+    const script = try std.fmt.allocPrint(work_allocator, "exec 2>&1\n{s}\n", .{command});
+    defer work_allocator.free(script);
+    const output = try compat.runOutputWithStdin(work_allocator, &.{ "/bin/sh", "-s" }, env, script, max_command_output_bytes);
     defer work_allocator.free(output.stdout);
     return .{
         .stdout = try allocator.dupe(u8, output.stdout),
@@ -159,7 +170,8 @@ pub fn runCommandDetailedWithRunner(allocator: std.mem.Allocator, command: []con
     };
 }
 
-pub fn uploadExecResult(allocator: std.mem.Allocator, cfg: anytype, task_id: []const u8, command: []const u8) !void {
+pub fn uploadExecResult(allocator: std.mem.Allocator, cfg: anytype, protocol_version: i32, task_id: []const u8, command: []const u8) !void {
+    _ = protocol_version;
     if (task_id.len == 0) return;
     const result = if (cfg.disable_web_ssh)
         try disabledRemoteControlResult(allocator)
@@ -203,6 +215,90 @@ pub fn normalizeCommandOutput(allocator: std.mem.Allocator, output: []const u8) 
         }
     }
     return normalized.toOwnedSlice(allocator);
+}
+
+fn createWindowsTaskScript(allocator: std.mem.Allocator, command: []const u8) ![]const u8 {
+    const temp_dir_result = try windowsTaskTempDir(allocator);
+    const temp_dir = temp_dir_result.path;
+    defer if (temp_dir_result.owned) allocator.free(temp_dir);
+    var seed: u64 = @truncate(@as(u128, @bitCast(compat.nanoTimestamp())));
+    var attempt: usize = 0;
+    while (attempt < 32) : (attempt += 1) {
+        seed +%= 0x9e3779b97f4a7c15;
+        const candidate = try std.fmt.allocPrint(allocator, "{s}\\komari-task-{x}-{d}.ps1", .{ temp_dir, seed, attempt });
+        errdefer allocator.free(candidate);
+        var file = compat.createFileAbsolute(candidate, .{ .exclusive = true, .read = true, .permissions = compat.private_file_permissions }) catch |err| switch (err) {
+            error.PathAlreadyExists => {
+                allocator.free(candidate);
+                continue;
+            },
+            else => return err,
+        };
+        errdefer {
+            file.close(std.Options.debug_io);
+            compat.deleteFileAbsolute(candidate) catch {};
+        }
+        var writer_buf: [1024]u8 = undefined;
+        var writer = compat.fileWriter(file, &writer_buf);
+        try writer.writeAll(&.{ 0xEF, 0xBB, 0xBF });
+        try writer.writeAll("[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n");
+        try writer.writeAll(command);
+        try writer.flush();
+        file.close(std.Options.debug_io);
+        return candidate;
+    }
+    return error.FileBusy;
+}
+
+const TempDirResult = struct {
+    path: []const u8,
+    owned: bool,
+};
+
+fn windowsTaskTempDir(allocator: std.mem.Allocator) !TempDirResult {
+    if (builtin.os.tag != .windows) return .{ .path = ".", .owned = false };
+    if (compat.getEnvVarOwned(allocator, "TEMP")) |value| {
+        if (value.len != 0) return .{ .path = value, .owned = true };
+        allocator.free(value);
+    } else |_| {}
+    if (compat.getEnvVarOwned(allocator, "TMP")) |value| {
+        if (value.len != 0) return .{ .path = value, .owned = true };
+        allocator.free(value);
+    } else |_| {}
+    return .{ .path = windowsFallbackTempDir(), .owned = false };
+}
+
+fn windowsFallbackTempDir() []const u8 {
+    return "C:\\Windows\\Temp";
+}
+
+fn writeAllFd(fd: std.posix.fd_t, bytes: []const u8) !void {
+    var offset: usize = 0;
+    while (offset < bytes.len) {
+        const written = writeFdOnce(fd, bytes[offset..]) catch |err| switch (err) {
+            error.Interrupted => continue,
+            else => return err,
+        };
+        offset += written;
+    }
+}
+
+fn writeFdOnce(fd: std.posix.fd_t, bytes: []const u8) !usize {
+    if (comptime builtin.os.tag == .linux and !builtin.link_libc) {
+        const rc = std.os.linux.write(@intCast(fd), bytes.ptr, bytes.len);
+        return switch (std.os.linux.errno(rc)) {
+            .SUCCESS => rc,
+            .INTR => error.Interrupted,
+            else => error.WriteFailed,
+        };
+    }
+    const rc = std.c.write(@intCast(fd), bytes.ptr, bytes.len);
+    if (rc < 0) {
+        const err = @as(std.posix.E, @enumFromInt(std.c._errno().*));
+        if (err == .INTR) return error.Interrupted;
+        return error.WriteFailed;
+    }
+    return @intCast(rc);
 }
 
 fn exitCode(term: std.process.Child.Term) i32 {

--- a/src/protocol/types.zig
+++ b/src/protocol/types.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 pub const BasicInfoPayload = struct {
     cpu_name: []const u8,
     cpu_cores: u32,
+    cpu_physical_cores: u32 = 0,
     arch: []const u8,
     os: []const u8,
     kernel_version: []const u8,
@@ -80,10 +81,11 @@ pub const ReportPayload = struct {
     message: []const u8,
 };
 
-pub fn writeBasicInfoJson(writer: anytype, payload: BasicInfoPayload, include_kernel_version: bool) !void {
+pub fn writeBasicInfoJson(writer: anytype, payload: BasicInfoPayload, include_kernel_version: bool, include_physical_cores: bool) !void {
     try writer.writeAll("{");
     try writeField(writer, "cpu_name", payload.cpu_name, false);
     try writeIntField(writer, "cpu_cores", payload.cpu_cores, true);
+    if (include_physical_cores) try writeIntField(writer, "cpu_physical_cores", payload.cpu_physical_cores, true);
     try writeField(writer, "arch", payload.arch, true);
     try writeField(writer, "os", payload.os, true);
     if (include_kernel_version) try writeField(writer, "kernel_version", payload.kernel_version, true);

--- a/src/protocol/v2.zig
+++ b/src/protocol/v2.zig
@@ -1,0 +1,228 @@
+const std = @import("std");
+
+pub const Version = "2.0";
+pub const MethodAgentReport = "agent.report";
+pub const MethodAgentBasicInfo = "agent.basicInfo";
+pub const MethodAgentPingResult = "agent.pingResult";
+pub const MethodAgentTaskResult = "agent.taskResult";
+pub const MethodAgentExec = "agent.exec";
+pub const MethodAgentPing = "agent.ping";
+pub const MethodAgentMessage = "agent.message";
+pub const MethodAgentEvent = "agent.event";
+pub const MethodAgentTerminal = "agent.terminal.request";
+pub const MethodAgentPull = "agent.pull";
+
+pub const RpcError = struct {
+    code: i32 = 0,
+    message: []const u8 = "",
+};
+
+pub const Event = struct {
+    id: []const u8 = "",
+    method: []const u8 = "",
+    params: ?std.json.Value = null,
+};
+
+pub const EventResult = struct {
+    status: []const u8 = "",
+    events: []Event = &.{},
+};
+
+pub const ParsedResponse = struct {
+    result: ?std.json.Value = null,
+    rpc_error: ?RpcError = null,
+};
+
+pub const PullParams = struct {
+    capabilities: []const []const u8,
+    ack_event_ids: []const []const u8,
+};
+
+pub fn writeNotification(writer: anytype, method: []const u8, params_json: []const u8) !void {
+    try writer.print("{{\"jsonrpc\":\"{s}\",\"method\":{f}", .{ Version, std.json.fmt(method, .{}) });
+    if (params_json.len != 0) try writer.print(",\"params\":{s}", .{params_json});
+    try writer.writeAll("}");
+}
+
+pub fn writeRequest(writer: anytype, id: []const u8, method: []const u8, params_json: []const u8) !void {
+    try writer.print("{{\"jsonrpc\":\"{s}\",\"method\":{f}", .{ Version, std.json.fmt(method, .{}) });
+    if (params_json.len != 0) try writer.print(",\"params\":{s}", .{params_json});
+    try writer.print(",\"id\":{f}}}", .{std.json.fmt(id, .{})});
+}
+
+pub fn allocReportNotification(allocator: std.mem.Allocator, report_json: []const u8) ![]u8 {
+    var params = std.Io.Writer.Allocating.init(allocator);
+    defer params.deinit();
+    try params.writer.print("{{\"report\":{s}}}", .{report_json});
+
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    try writeNotification(&out.writer, MethodAgentReport, params.writer.buffered());
+    return out.toOwnedSlice();
+}
+
+pub fn allocReportRequest(allocator: std.mem.Allocator, id: []const u8, report_json: []const u8, ack_event_ids: []const []const u8) ![]u8 {
+    var params = std.Io.Writer.Allocating.init(allocator);
+    defer params.deinit();
+    try params.writer.print("{{\"report\":{s},\"ack_event_ids\":[", .{report_json});
+    for (ack_event_ids, 0..) |ack_id, i| {
+        if (i != 0) try params.writer.writeAll(",");
+        try params.writer.print("{f}", .{std.json.fmt(ack_id, .{})});
+    }
+    try params.writer.writeAll("]}");
+
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    try writeRequest(&out.writer, id, MethodAgentReport, params.writer.buffered());
+    return out.toOwnedSlice();
+}
+
+pub fn allocBasicInfoNotification(allocator: std.mem.Allocator, info_json: []const u8) ![]u8 {
+    var params = std.Io.Writer.Allocating.init(allocator);
+    defer params.deinit();
+    try params.writer.print("{{\"info\":{s}}}", .{info_json});
+
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    try writeNotification(&out.writer, MethodAgentBasicInfo, params.writer.buffered());
+    return out.toOwnedSlice();
+}
+
+pub fn allocPingResultNotification(
+    allocator: std.mem.Allocator,
+    task_id: u64,
+    ping_type: []const u8,
+    value: i64,
+    finished_at: []const u8,
+) ![]u8 {
+    var params = std.Io.Writer.Allocating.init(allocator);
+    defer params.deinit();
+    try params.writer.print(
+        "{{\"task_id\":{},\"ping_type\":{f},\"value\":{},\"finished_at\":{f}}}",
+        .{ task_id, std.json.fmt(ping_type, .{}), value, std.json.fmt(finished_at, .{}) },
+    );
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    try writeNotification(&out.writer, MethodAgentPingResult, params.writer.buffered());
+    return out.toOwnedSlice();
+}
+
+pub fn allocTaskResultNotification(
+    allocator: std.mem.Allocator,
+    task_id: []const u8,
+    result: []const u8,
+    exit_code: i32,
+    finished_at: []const u8,
+) ![]u8 {
+    var params = std.Io.Writer.Allocating.init(allocator);
+    defer params.deinit();
+    try params.writer.print(
+        "{{\"task_id\":{f},\"result\":{f},\"exit_code\":{},\"finished_at\":{f}}}",
+        .{ std.json.fmt(task_id, .{}), std.json.fmt(result, .{}), exit_code, std.json.fmt(finished_at, .{}) },
+    );
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    try writeNotification(&out.writer, MethodAgentTaskResult, params.writer.buffered());
+    return out.toOwnedSlice();
+}
+
+pub fn allocPullRequest(allocator: std.mem.Allocator, id: []const u8, params: PullParams) ![]u8 {
+    var body = std.Io.Writer.Allocating.init(allocator);
+    defer body.deinit();
+    try body.writer.writeAll("{\"capabilities\":[");
+    for (params.capabilities, 0..) |capability, i| {
+        if (i != 0) try body.writer.writeAll(",");
+        try body.writer.print("{f}", .{std.json.fmt(capability, .{})});
+    }
+    try body.writer.writeAll("],\"ack_event_ids\":[");
+    for (params.ack_event_ids, 0..) |ack_id, i| {
+        if (i != 0) try body.writer.writeAll(",");
+        try body.writer.print("{f}", .{std.json.fmt(ack_id, .{})});
+    }
+    try body.writer.writeAll("]}");
+
+    var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
+    try writeRequest(&out.writer, id, MethodAgentPull, body.writer.buffered());
+    return out.toOwnedSlice();
+}
+
+pub fn parseResponse(allocator: std.mem.Allocator, body: []const u8) !ParsedResponse {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+    if (parsed.value != .object) return error.InvalidV2Response;
+    const object = parsed.value.object;
+    const jsonrpc = object.get("jsonrpc") orelse return error.InvalidV2Response;
+    if (jsonrpc != .string or !std.mem.eql(u8, jsonrpc.string, Version)) return error.InvalidV2Response;
+
+    var result: ParsedResponse = .{};
+    if (object.get("error")) |err_value| {
+        if (err_value != .object) return error.InvalidV2Response;
+        const err_obj = err_value.object;
+        result.rpc_error = .{
+            .code = intField(err_obj, "code"),
+            .message = stringField(err_obj, "message"),
+        };
+    }
+    if (object.get("result")) |result_value| {
+        result.result = result_value;
+    }
+    return result;
+}
+
+pub fn parseEventResult(allocator: std.mem.Allocator, value: std.json.Value) !EventResult {
+    if (value != .object) return error.InvalidV2EventResult;
+    const object = value.object;
+    var events_out: std.ArrayList(Event) = .empty;
+    errdefer {
+        for (events_out.items) |event| {
+            allocator.free(event.id);
+            allocator.free(event.method);
+        }
+        events_out.deinit(allocator);
+    }
+
+    if (object.get("events")) |events_value| {
+        if (events_value != .array) return error.InvalidV2EventResult;
+        for (events_value.array.items) |item| {
+            if (item != .object) continue;
+            const event_obj = item.object;
+            try events_out.append(allocator, .{
+                .id = try allocator.dupe(u8, stringField(event_obj, "id")),
+                .method = try allocator.dupe(u8, stringField(event_obj, "method")),
+                .params = event_obj.get("params"),
+            });
+        }
+    }
+
+    return .{
+        .status = if (object.get("status")) |status| if (status == .string) try allocator.dupe(u8, status.string) else try allocator.dupe(u8, "") else try allocator.dupe(u8, ""),
+        .events = try events_out.toOwnedSlice(allocator),
+    };
+}
+
+pub fn deinitEventResult(allocator: std.mem.Allocator, result: EventResult) void {
+    allocator.free(result.status);
+    for (result.events) |event| {
+        allocator.free(event.id);
+        allocator.free(event.method);
+    }
+    allocator.free(result.events);
+}
+
+fn intField(object: std.json.ObjectMap, key: []const u8) i32 {
+    if (object.get(key)) |value| {
+        return switch (value) {
+            .integer => |n| @intCast(n),
+            .string => |text| std.fmt.parseInt(i32, text, 10) catch 0,
+            else => 0,
+        };
+    }
+    return 0;
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) []const u8 {
+    if (object.get(key)) |value| {
+        if (value == .string) return value.string;
+    }
+    return "";
+}

--- a/src/protocol/v2_state.zig
+++ b/src/protocol/v2_state.zig
@@ -1,0 +1,70 @@
+const std = @import("std");
+
+const fallback_threshold = 3;
+
+var requested_protocol_version = std.atomic.Value(i32).init(2);
+var connection_protocol_version = std.atomic.Value(i32).init(0);
+var v2_protocol_failures = std.atomic.Value(u32).init(0);
+
+pub fn initRequestedProtocolVersion(version: i32) void {
+    requested_protocol_version.store(if (version >= 2) 2 else 1, .release);
+}
+
+pub fn requestedProtocolVersion() i32 {
+    return if (requested_protocol_version.load(.acquire) >= 2) 2 else 1;
+}
+
+pub fn uploadProtocolVersion() i32 {
+    const connection_version = connection_protocol_version.load(.acquire);
+    if (connection_version > 0) return connection_version;
+    return requestedProtocolVersion();
+}
+
+pub fn setConnectionProtocolVersion(version: i32) void {
+    connection_protocol_version.store(version, .release);
+    if (version >= 2) v2_protocol_failures.store(0, .release);
+}
+
+pub fn resetConnectionProtocolVersion() void {
+    connection_protocol_version.store(0, .release);
+    v2_protocol_failures.store(0, .release);
+}
+
+pub fn resetV2ProtocolFailures(protocol_version: i32) void {
+    if (protocol_version >= 2 and requestedProtocolVersion() >= 2) {
+        v2_protocol_failures.store(0, .release);
+    }
+}
+
+pub fn noteV2AttemptResult(protocol_version: i32, err: ?anyerror) struct { failures: u32, fallback: bool } {
+    if (protocol_version < 2 or requestedProtocolVersion() < 2) return .{ .failures = 0, .fallback = false };
+    if (err == null) {
+        resetV2ProtocolFailures(protocol_version);
+        return .{ .failures = 0, .fallback = false };
+    }
+    if (!isV2ProtocolFailure(err.?)) {
+        return .{ .failures = v2_protocol_failures.load(.acquire), .fallback = false };
+    }
+    const failures = v2_protocol_failures.fetchAdd(1, .acq_rel) + 1;
+    return .{ .failures = failures, .fallback = failures >= fallback_threshold };
+}
+
+pub fn shouldFallbackToV1(protocol_version: i32, err: anyerror) bool {
+    const result = noteV2AttemptResult(protocol_version, err);
+    return result.fallback;
+}
+
+pub fn isV2ProtocolFailure(err: anyerror) bool {
+    return switch (err) {
+        error.HttpStatusNotOk,
+        error.HttpRedirectMissingLocation,
+        error.HttpTooManyRedirects,
+        error.HttpResponseTooLarge,
+        error.WebSocketHandshakeFailed,
+        error.InvalidHttpResponse,
+        error.InvalidV2Response,
+        error.InvalidV2EventResult,
+        => true,
+        else => false,
+    };
+}

--- a/src/protocol/ws_client.zig
+++ b/src/protocol/ws_client.zig
@@ -184,7 +184,7 @@ fn connectRaw(allocator: std.mem.Allocator, url: []const u8, cfg: anytype) !*Cli
     const target = try parseUrl(url);
     const scheme = if (target.tls) "wss" else "ws";
     debug.log("websocket transport connect start host={s} port={d} tls={}", .{ target.host, target.port, target.tls });
-    const raw_http = try http.connectRawHttp(allocator, scheme, target.host, target.port, target.tls, cfg.ignore_unsafe_cert, cfg.custom_dns, .any, http.timeoutMsForConfig(cfg));
+    const raw_http = try http.connectRawHttp(allocator, scheme, target.host, target.port, target.tls, cfg.ignore_unsafe_cert, cfg.custom_dns, http.dashboardAddressFamily(cfg), http.timeoutMsForConfig(cfg));
     errdefer raw_http.close(allocator);
     const raw = raw_http.conn;
     debug.log("websocket transport connected host={s} port={d}", .{ target.host, target.port });

--- a/src/protocol/ws_message.zig
+++ b/src/protocol/ws_message.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const v2 = @import("v2.zig");
 
 /// Parsing for websocket messages delivered by the Komari server.
 pub const ServerMessageKind = enum {
@@ -6,11 +7,16 @@ pub const ServerMessageKind = enum {
     terminal,
     exec,
     ping,
+    message,
+    event,
 };
 
 pub const ServerMessage = struct {
     kind: ServerMessageKind = .unknown,
     message: []const u8 = "",
+    jsonrpc: []const u8 = "",
+    method: []const u8 = "",
+    event_id: []const u8 = "",
     request_id: []const u8 = "",
     task_id: []const u8 = "",
     command: []const u8 = "",
@@ -22,6 +28,9 @@ pub const ServerMessage = struct {
     pub fn deinit(self: ServerMessage, allocator: std.mem.Allocator) void {
         if (!self.owns_fields) return;
         if (self.message.len != 0) allocator.free(self.message);
+        if (self.jsonrpc.len != 0) allocator.free(self.jsonrpc);
+        if (self.method.len != 0) allocator.free(self.method);
+        if (self.event_id.len != 0) allocator.free(self.event_id);
         if (self.request_id.len != 0) allocator.free(self.request_id);
         if (self.task_id.len != 0) allocator.free(self.task_id);
         if (self.command.len != 0) allocator.free(self.command);
@@ -38,6 +47,9 @@ pub fn parseServerMessage(allocator: std.mem.Allocator, bytes: []const u8) !Serv
 
     var msg = ServerMessage{
         .message = try dupeString(allocator, object, "message"),
+        .jsonrpc = try dupeString(allocator, object, "jsonrpc"),
+        .method = try dupeString(allocator, object, "method"),
+        .event_id = try dupeString(allocator, object, "id"),
         .request_id = try dupeString(allocator, object, "request_id"),
         .task_id = try dupeString(allocator, object, "task_id"),
         .command = try dupeString(allocator, object, "command"),
@@ -45,6 +57,12 @@ pub fn parseServerMessage(allocator: std.mem.Allocator, bytes: []const u8) !Serv
         .ping_type = try dupeString(allocator, object, "ping_type"),
         .ping_target = try dupeString(allocator, object, "ping_target"),
     };
+    errdefer msg.deinit(allocator);
+    if (msg.jsonrpc.len != 0 and std.mem.eql(u8, msg.jsonrpc, v2.Version)) {
+        if (object.get("params")) |params_value| {
+            if (params_value == .object) try fillFromV2ParamsOwned(allocator, &msg, params_value.object);
+        }
+    }
 
     classify(&msg);
     return msg;
@@ -68,6 +86,12 @@ pub fn parseServerMessageLeaky(allocator: std.mem.Allocator, bytes: []const u8) 
         };
         if (std.mem.eql(u8, key, "message")) {
             msg.message = try readStringValueLeaky(allocator, &scanner);
+        } else if (std.mem.eql(u8, key, "jsonrpc")) {
+            msg.jsonrpc = try readStringValueLeaky(allocator, &scanner);
+        } else if (std.mem.eql(u8, key, "method")) {
+            msg.method = try readStringValueLeaky(allocator, &scanner);
+        } else if (std.mem.eql(u8, key, "id")) {
+            msg.event_id = try readStringValueLeaky(allocator, &scanner);
         } else if (std.mem.eql(u8, key, "request_id")) {
             msg.request_id = try readStringValueLeaky(allocator, &scanner);
         } else if (std.mem.eql(u8, key, "task_id")) {
@@ -84,6 +108,12 @@ pub fn parseServerMessageLeaky(allocator: std.mem.Allocator, bytes: []const u8) 
             msg.ping_type = try readStringValueLeaky(allocator, &scanner);
         } else if (std.mem.eql(u8, key, "ping_target")) {
             msg.ping_target = try readStringValueLeaky(allocator, &scanner);
+        } else if (std.mem.eql(u8, key, "params")) {
+            if (msg.jsonrpc.len != 0 and std.mem.eql(u8, msg.jsonrpc, v2.Version)) {
+                try readV2ParamsLeaky(allocator, &scanner, &msg);
+            } else {
+                try scanner.skipValue();
+            }
         } else {
             try scanner.skipValue();
         }
@@ -151,11 +181,84 @@ fn pingTaskIdValue(object: std.json.ObjectMap) u64 {
 }
 
 fn classify(msg: *ServerMessage) void {
+    if (msg.jsonrpc.len != 0 and std.mem.eql(u8, msg.jsonrpc, v2.Version)) {
+        if (std.mem.eql(u8, msg.method, v2.MethodAgentTerminal)) {
+            msg.kind = .terminal;
+        } else if (std.mem.eql(u8, msg.method, v2.MethodAgentExec)) {
+            msg.kind = .exec;
+        } else if (std.mem.eql(u8, msg.method, v2.MethodAgentPing)) {
+            msg.kind = .ping;
+        } else if (std.mem.eql(u8, msg.method, v2.MethodAgentMessage)) {
+            msg.kind = .message;
+        } else if (std.mem.eql(u8, msg.method, v2.MethodAgentEvent)) {
+            msg.kind = .event;
+        }
+        return;
+    }
     if (std.mem.eql(u8, msg.message, "terminal") or msg.request_id.len != 0) {
         msg.kind = .terminal;
     } else if (std.mem.eql(u8, msg.message, "exec")) {
         msg.kind = .exec;
     } else if (std.mem.eql(u8, msg.message, "ping") or msg.ping_task_id != 0 or msg.ping_type.len != 0 or msg.ping_target.len != 0) {
         msg.kind = .ping;
+    }
+}
+
+fn fillFromV2ParamsOwned(allocator: std.mem.Allocator, msg: *ServerMessage, object: std.json.ObjectMap) !void {
+    if (msg.request_id.len == 0) msg.request_id = try dupeObjectString(allocator, object, "request_id");
+    if (msg.task_id.len == 0) msg.task_id = try dupeObjectString(allocator, object, "task_id");
+    if (msg.command.len == 0) msg.command = try dupeObjectString(allocator, object, "command");
+    if (msg.ping_task_id == 0) msg.ping_task_id = intValue(object, "ping_task_id");
+    if (msg.ping_type.len == 0) msg.ping_type = try dupeObjectString(allocator, object, "ping_type");
+    if (msg.ping_target.len == 0) msg.ping_target = try dupeObjectString(allocator, object, "ping_target");
+}
+
+fn stringValue(object: std.json.ObjectMap, key: []const u8) []const u8 {
+    if (object.get(key)) |value| {
+        if (value == .string) return value.string;
+    }
+    return "";
+}
+
+fn dupeObjectString(allocator: std.mem.Allocator, object: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    if (object.get(key)) |value| {
+        if (value == .string) return allocator.dupe(u8, value.string);
+    }
+    return "";
+}
+
+fn readV2ParamsLeaky(allocator: std.mem.Allocator, scanner: *std.json.Scanner, msg: *ServerMessage) !void {
+    if (try scanner.peekNextTokenType() != .object_begin) {
+        try scanner.skipValue();
+        return;
+    }
+    _ = try scanner.next();
+    while (true) {
+        const key_token = try scanner.nextAlloc(allocator, .alloc_if_needed);
+        const key = switch (key_token) {
+            .object_end => break,
+            .string => |value| value,
+            .allocated_string => |value| value,
+            else => return error.InvalidJson,
+        };
+        if (std.mem.eql(u8, key, "request_id")) {
+            msg.request_id = try readStringValueLeaky(allocator, scanner);
+        } else if (std.mem.eql(u8, key, "task_id")) {
+            if (try scanner.peekNextTokenType() == .number) {
+                msg.ping_task_id = try readU64Value(allocator, scanner);
+            } else {
+                msg.task_id = try readStringValueLeaky(allocator, scanner);
+            }
+        } else if (std.mem.eql(u8, key, "command")) {
+            msg.command = try readStringValueLeaky(allocator, scanner);
+        } else if (std.mem.eql(u8, key, "ping_task_id")) {
+            msg.ping_task_id = try readU64Value(allocator, scanner);
+        } else if (std.mem.eql(u8, key, "ping_type")) {
+            msg.ping_type = try readStringValueLeaky(allocator, scanner);
+        } else if (std.mem.eql(u8, key, "ping_target")) {
+            msg.ping_target = try readStringValueLeaky(allocator, scanner);
+        } else {
+            try scanner.skipValue();
+        }
     }
 }

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -201,7 +201,7 @@ fn startZigPtyWithPrelude(allocator: std.mem.Allocator, use_prelude: bool) !Shel
     const shell_base_raw = std.fs.path.basename(shell_path);
     const shell_base = try allocator.dupeZ(u8, shell_base_raw);
     defer allocator.free(shell_base);
-    const prelude = if (use_prelude) try allocator.dupeZ(u8, "for f in /etc/update-motd.d/*; do [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\"") else null;
+    const prelude = if (use_prelude) try allocator.dupeZ(u8, buildShellPrelude(shell_base_raw)) else null;
     defer if (prelude) |value| allocator.free(value);
     const cwd = try terminalCwdAlloc(allocator);
     defer allocator.free(cwd);
@@ -262,7 +262,7 @@ fn startBsdPtyWithPrelude(allocator: std.mem.Allocator, use_prelude: bool) !Shel
     const shell_base_raw = std.fs.path.basename(shell_path);
     const shell_base = try allocator.dupeZ(u8, shell_base_raw);
     defer allocator.free(shell_base);
-    const prelude = if (use_prelude) try allocator.dupeZ(u8, "for f in /etc/update-motd.d/*; do [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\"") else null;
+    const prelude = if (use_prelude) try allocator.dupeZ(u8, buildShellPrelude(shell_base_raw)) else null;
     defer if (prelude) |value| allocator.free(value);
     var env_arena = std.heap.ArenaAllocator.init(allocator);
     defer env_arena.deinit();
@@ -415,6 +415,12 @@ fn isExecutable(path: []const u8) bool {
     return true;
 }
 
+fn buildShellPrelude(shell_base: []const u8) []const u8 {
+    const motd = "for f in /etc/update-motd.d/*; do [ -e \"$f\" ] && [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\"";
+    if (std.mem.eql(u8, shell_base, "zsh")) return "unsetopt NOMATCH 2>/dev/null; " ++ motd;
+    return motd;
+}
+
 fn terminalEnv(allocator: std.mem.Allocator) !*std.process.Environ.Map {
     var env = try allocator.create(std.process.Environ.Map);
     env.* = if (builtin.os.tag == .windows) try compat.currentEnvMap(allocator) else compat.emptyEnvMap(allocator);
@@ -462,14 +468,30 @@ fn terminalCwdAlloc(allocator: std.mem.Allocator) ![]u8 {
 fn writeUnixFdAll(fd: std.posix.fd_t, bytes: []const u8) !void {
     var offset: usize = 0;
     while (offset < bytes.len) {
-        const rc = std.c.write(@intCast(fd), bytes.ptr + offset, bytes.len - offset);
-        if (rc < 0) {
-            const err = @as(std.posix.E, @enumFromInt(std.c._errno().*));
-            if (err == .INTR) continue;
-            return error.WriteFailed;
-        }
-        offset += @intCast(rc);
+        const written = writeFdOnce(fd, bytes[offset..]) catch |err| switch (err) {
+            error.Interrupted => continue,
+            else => return err,
+        };
+        offset += written;
     }
+}
+
+fn writeFdOnce(fd: std.posix.fd_t, bytes: []const u8) !usize {
+    if (comptime builtin.os.tag == .linux and !builtin.link_libc) {
+        const rc = std.os.linux.write(@intCast(fd), bytes.ptr, bytes.len);
+        return switch (std.os.linux.errno(rc)) {
+            .SUCCESS => rc,
+            .INTR => error.Interrupted,
+            else => error.WriteFailed,
+        };
+    }
+    const rc = std.c.write(@intCast(fd), bytes.ptr, bytes.len);
+    if (rc < 0) {
+        const err = @as(std.posix.E, @enumFromInt(std.c._errno().*));
+        if (err == .INTR) return error.Interrupted;
+        return error.WriteFailed;
+    }
+    return @intCast(rc);
 }
 
 fn readUnixFd(fd: std.posix.fd_t, buf: []u8) !usize {

--- a/test/basic_info_flow_test.zig
+++ b/test/basic_info_flow_test.zig
@@ -58,3 +58,14 @@ test "foreground upload failure during websocket reconnect is tolerated and logg
 
     try std.testing.expectEqualStrings("Basic info upload failed during websocket reconnect: HttpStatusNotOk\n", out.written());
 }
+
+test "foreground upload failure during websocket reconnect keeps protocol failure semantics" {
+    var out = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer out.deinit();
+
+    const outcome = try flow.handleForegroundUploadResult(&out.writer, .websocket_reconnect, error.InvalidV2Response);
+    switch (outcome) {
+        .success, .deferred => return error.TestUnexpectedResult,
+        .failure => |err| try std.testing.expectEqual(error.InvalidV2Response, err),
+    }
+}

--- a/test/config_test.zig
+++ b/test/config_test.zig
@@ -7,6 +7,9 @@ test "defaults match Go agent" {
     try std.testing.expectEqual(@as(i32, 3), cfg.max_retries);
     try std.testing.expectEqual(@as(i32, 5), cfg.reconnect_interval);
     try std.testing.expectEqual(@as(i32, 5), cfg.info_report_interval);
+    try std.testing.expectEqual(@as(i32, 2), cfg.protocol_version);
+    try std.testing.expect(!cfg.disable_compression);
+    try std.testing.expectEqualStrings("", cfg.prefer_ip_version);
     try std.testing.expect(!cfg.disable_auto_update);
     try std.testing.expect(!cfg.disable_web_ssh);
     try std.testing.expect(!cfg.debug_log);
@@ -41,6 +44,11 @@ test "full go-compatible cli flags parse" {
         "--disable-web-ssh",
         "--info-report-interval",
         "30",
+        "--protocol-version",
+        "2",
+        "--disable-compression",
+        "--prefer-ip-version",
+        "6",
         "--include-nics",
         "eth0,wlan0",
         "--exclude-nics",
@@ -74,6 +82,9 @@ test "full go-compatible cli flags parse" {
     try std.testing.expect(cfg.disable_auto_update);
     try std.testing.expect(cfg.disable_web_ssh);
     try std.testing.expectEqual(@as(i32, 30), cfg.info_report_interval);
+    try std.testing.expectEqual(@as(i32, 2), cfg.protocol_version);
+    try std.testing.expect(cfg.disable_compression);
+    try std.testing.expectEqualStrings("6", cfg.prefer_ip_version);
     try std.testing.expectEqualStrings("eth0,wlan0", cfg.include_nics);
     try std.testing.expectEqualStrings("docker0", cfg.exclude_nics);
     try std.testing.expectEqualStrings("/;/data", cfg.include_mountpoints);
@@ -103,6 +114,9 @@ test "go-style equals cli flags parse" {
         "--interval=2.5",
         "--max-retries=8",
         "--reconnect-interval=13",
+        "--protocol-version=1",
+        "--disable-compression=true",
+        "--prefer-ip-version=4",
         "--include-nics=eth*",
         "--exclude-nics=docker*",
         "--include-mountpoint=/;/data",
@@ -117,6 +131,9 @@ test "go-style equals cli flags parse" {
     try std.testing.expectEqual(@as(f64, 2.5), cfg.interval);
     try std.testing.expectEqual(@as(i32, 8), cfg.max_retries);
     try std.testing.expectEqual(@as(i32, 13), cfg.reconnect_interval);
+    try std.testing.expectEqual(@as(i32, 1), cfg.protocol_version);
+    try std.testing.expect(cfg.disable_compression);
+    try std.testing.expectEqualStrings("4", cfg.prefer_ip_version);
     try std.testing.expectEqualStrings("eth*", cfg.include_nics);
     try std.testing.expectEqualStrings("docker*", cfg.exclude_nics);
     try std.testing.expectEqualStrings("/;/data", cfg.include_mountpoints);
@@ -136,6 +153,7 @@ test "go-style equals bool cli flags parse" {
         "--ignore-unsafe-cert=true",
         "--memory-include-cache=true",
         "--memory-exclude-bcf=true",
+        "--disable-compression=true",
         "--gpu=true",
         "--show-warning=true",
         "--debug-log=true",
@@ -148,6 +166,7 @@ test "go-style equals bool cli flags parse" {
     try std.testing.expect(cfg.ignore_unsafe_cert);
     try std.testing.expect(cfg.memory_include_cache);
     try std.testing.expect(cfg.memory_report_raw_used);
+    try std.testing.expect(cfg.disable_compression);
     try std.testing.expect(cfg.enable_gpu);
     try std.testing.expect(cfg.show_warning);
     try std.testing.expect(cfg.debug_log);
@@ -246,6 +265,9 @@ test "json config keys parse" {
         \\  "max_retries": 9,
         \\  "reconnect_interval": 12,
         \\  "info_report_interval": 30,
+        \\  "protocol_version": 1,
+        \\  "disable_compression": true,
+        \\  "prefer_ip_version": "4",
         \\  "include_nics": "eth0",
         \\  "month_rotate": 15,
         \\  "cf_access_client_id": "id",
@@ -272,6 +294,9 @@ test "json config keys parse" {
     try std.testing.expectEqual(@as(i32, 9), cfg.max_retries);
     try std.testing.expectEqual(@as(i32, 12), cfg.reconnect_interval);
     try std.testing.expectEqual(@as(i32, 30), cfg.info_report_interval);
+    try std.testing.expectEqual(@as(i32, 1), cfg.protocol_version);
+    try std.testing.expect(cfg.disable_compression);
+    try std.testing.expectEqualStrings("4", cfg.prefer_ip_version);
     try std.testing.expectEqualStrings("eth0", cfg.include_nics);
     try std.testing.expectEqual(@as(i32, 15), cfg.month_rotate);
     try std.testing.expectEqualStrings("id", cfg.cf_access_client_id);
@@ -285,4 +310,18 @@ test "json config keys parse" {
     try std.testing.expectEqualStrings("2001:db8::1", cfg.custom_ipv6);
     try std.testing.expect(cfg.get_ip_addr_from_nic);
     try std.testing.expectEqualStrings("/host/proc", cfg.host_proc);
+}
+
+test "config normalize defaults protocol version zero and validates values" {
+    var cfg = config.Config.default();
+    cfg.protocol_version = 0;
+    try cfg.normalize();
+    try std.testing.expectEqual(@as(i32, 2), cfg.protocol_version);
+
+    cfg.protocol_version = 9;
+    try std.testing.expectError(error.InvalidProtocolVersion, cfg.normalize());
+
+    cfg.protocol_version = 2;
+    cfg.prefer_ip_version = "5";
+    try std.testing.expectError(error.InvalidPreferIpVersion, cfg.normalize());
 }

--- a/test/golden/basic_info.json
+++ b/test/golden/basic_info.json
@@ -1,1 +1,1 @@
-{"cpu_name":"CPU","cpu_cores":4,"arch":"amd64","os":"linux","kernel_version":"6.1.0","ipv4":"192.0.2.1","ipv6":"2001:db8::1","mem_total":1024,"swap_total":2048,"disk_total":4096,"gpu_name":"GPU","virtualization":"kvm","version":"0.0.1"}
+{"cpu_name":"CPU","cpu_cores":4,"cpu_physical_cores":2,"arch":"amd64","os":"linux","kernel_version":"6.1.0","ipv4":"192.0.2.1","ipv6":"2001:db8::1","mem_total":1024,"swap_total":2048,"disk_total":4096,"gpu_name":"GPU","virtualization":"kvm","version":"0.0.1"}

--- a/test/http_test.zig
+++ b/test/http_test.zig
@@ -17,6 +17,10 @@ test "endpoint helpers trim slash and place token query" {
         try http.taskResultUrl(allocator, "https://panel.example/", "tok"),
     );
     try std.testing.expectEqualStrings(
+        "https://panel.example/api/clients/v2/rpc?token=tok",
+        try http.v2RpcUrl(allocator, "https://panel.example/", "tok"),
+    );
+    try std.testing.expectEqualStrings(
         "https://panel.example/api/clients/register?name=host%20one",
         try http.registerUrl(allocator, "https://panel.example/", "host one"),
     );
@@ -36,6 +40,10 @@ test "websocket helpers convert scheme" {
         try http.reportWsUrl(allocator, "https://panel.example/", "tok"),
     );
     try std.testing.expectEqualStrings(
+        "wss://panel.example/api/clients/v2/rpc?token=tok",
+        try http.reportWsUrlForProtocol(allocator, "https://panel.example/", "tok", 2),
+    );
+    try std.testing.expectEqualStrings(
         "ws://panel.example/api/clients/terminal?token=tok&id=req",
         try http.terminalWsUrl(allocator, "http://panel.example/", "tok", "req"),
     );
@@ -43,6 +51,12 @@ test "websocket helpers convert scheme" {
         "wspanel.example/api/clients/report?token=tok",
         try http.reportWsUrl(allocator, "panel.example/", "tok"),
     );
+}
+
+test "dashboard address family follows prefer ip version" {
+    try std.testing.expectEqualStrings("any", @tagName(http.dashboardAddressFamily(config.Config{})));
+    try std.testing.expectEqualStrings("ipv4", @tagName(http.dashboardAddressFamily(config.Config{ .prefer_ip_version = "4" })));
+    try std.testing.expectEqualStrings("ipv6", @tagName(http.dashboardAddressFamily(config.Config{ .prefer_ip_version = "6" })));
 }
 
 test "cloudflare access headers are added when both values exist" {

--- a/test/local_http.zig
+++ b/test/local_http.zig
@@ -1,13 +1,55 @@
 const std = @import("std");
 
+pub const RecordedRequest = struct {
+    head: []u8,
+    body: []u8,
+
+    pub fn deinit(self: RecordedRequest, allocator: std.mem.Allocator) void {
+        allocator.free(self.head);
+        allocator.free(self.body);
+    }
+
+    pub fn requestLine(self: RecordedRequest) []const u8 {
+        const end = std.mem.indexOf(u8, self.head, "\r\n") orelse self.head.len;
+        return self.head[0..end];
+    }
+
+    pub fn header(self: RecordedRequest, name: []const u8) ?[]const u8 {
+        var lines = std.mem.splitSequence(u8, self.head, "\r\n");
+        _ = lines.next();
+        while (lines.next()) |line| {
+            if (line.len == 0) break;
+            const sep = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+            const key = std.mem.trim(u8, line[0..sep], " \t");
+            if (!std.ascii.eqlIgnoreCase(key, name)) continue;
+            return std.mem.trim(u8, line[sep + 1 ..], " \t");
+        }
+        return null;
+    }
+};
+
+pub const CompletedServer = struct {
+    allocator: std.mem.Allocator,
+    requests: []RecordedRequest,
+
+    pub fn deinit(self: *CompletedServer) void {
+        for (self.requests) |request| request.deinit(self.allocator);
+        self.allocator.free(self.requests);
+        self.* = undefined;
+    }
+};
+
 pub const Server = struct {
     allocator: std.mem.Allocator,
     ctx: *Context,
     thread: std.Thread,
+    joined: bool = false,
 
     const Context = struct {
+        allocator: std.mem.Allocator,
         listener: std.Io.net.Server,
         responses: []const []const u8,
+        requests: std.ArrayList(RecordedRequest) = .empty,
         err: ?anyerror = null,
     };
 
@@ -19,6 +61,7 @@ pub const Server = struct {
         const ctx = try allocator.create(Context);
         errdefer allocator.destroy(ctx);
         ctx.* = .{
+            .allocator = allocator,
             .listener = listener,
             .responses = responses,
         };
@@ -34,10 +77,20 @@ pub const Server = struct {
     }
 
     pub fn join(self: *Server) !void {
-        self.thread.join();
-        self.ctx.listener.deinit(std.Options.debug_io);
-        defer self.allocator.destroy(self.ctx);
-        if (self.ctx.err) |err| return err;
+        const ctx = self.ctx;
+        defer self.allocator.destroy(ctx);
+        defer freeRequests(self.allocator, &ctx.requests);
+        try self.wait();
+    }
+
+    pub fn finish(self: *Server) !CompletedServer {
+        const ctx = self.ctx;
+        defer self.allocator.destroy(ctx);
+        try self.wait();
+        return .{
+            .allocator = self.allocator,
+            .requests = try ctx.requests.toOwnedSlice(self.allocator),
+        };
     }
 
     fn serve(ctx: *Context) void {
@@ -48,7 +101,12 @@ pub const Server = struct {
             };
             defer stream.close(std.Options.debug_io);
 
-            readRequest(&stream) catch |err| {
+            const request = readRequest(ctx.allocator, &stream) catch |err| {
+                ctx.err = err;
+                return;
+            };
+            ctx.requests.append(ctx.allocator, request) catch |err| {
+                request.deinit(ctx.allocator);
                 ctx.err = err;
                 return;
             };
@@ -59,17 +117,26 @@ pub const Server = struct {
         }
     }
 
-    fn readRequest(stream: *std.Io.net.Stream) !void {
+    fn readRequest(allocator: std.mem.Allocator, stream: *std.Io.net.Stream) !RecordedRequest {
         var reader_buf: [4096]u8 = undefined;
         var reader = stream.reader(std.Options.debug_io, &reader_buf);
-        var header: [4096]u8 = undefined;
-        var len: usize = 0;
-        while (len < header.len) {
-            header[len] = try reader.interface.takeByte();
-            len += 1;
-            if (std.mem.endsWith(u8, header[0..len], "\r\n\r\n")) return;
+        var head: std.ArrayList(u8) = .empty;
+        errdefer head.deinit(allocator);
+        while (head.items.len < 4096) {
+            try head.append(allocator, try reader.interface.takeByte());
+            if (std.mem.endsWith(u8, head.items, "\r\n\r\n")) break;
         }
-        return error.HttpRequestHeaderTooLarge;
+        if (!std.mem.endsWith(u8, head.items, "\r\n\r\n")) return error.HttpRequestHeaderTooLarge;
+
+        const content_length = parseContentLength(head.items) orelse 0;
+        const body = try allocator.alloc(u8, content_length);
+        errdefer allocator.free(body);
+        if (content_length != 0) try reader.interface.readSliceAll(body);
+
+        return .{
+            .head = try head.toOwnedSlice(allocator),
+            .body = body,
+        };
     }
 
     fn writeResponse(stream: *std.Io.net.Stream, response: []const u8) !void {
@@ -77,5 +144,33 @@ pub const Server = struct {
         var writer = stream.writer(std.Options.debug_io, &writer_buf);
         try writer.interface.writeAll(response);
         try writer.interface.flush();
+    }
+
+    fn wait(self: *Server) !void {
+        if (!self.joined) {
+            self.thread.join();
+            self.ctx.listener.deinit(std.Options.debug_io);
+            self.joined = true;
+        }
+        if (self.ctx.err) |err| return err;
+    }
+
+    fn freeRequests(allocator: std.mem.Allocator, requests: *std.ArrayList(RecordedRequest)) void {
+        for (requests.items) |request| request.deinit(allocator);
+        requests.deinit(allocator);
+    }
+
+    fn parseContentLength(head: []const u8) ?usize {
+        var lines = std.mem.splitSequence(u8, head, "\r\n");
+        _ = lines.next();
+        while (lines.next()) |line| {
+            if (line.len == 0) break;
+            const sep = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+            const name = std.mem.trim(u8, line[0..sep], " \t");
+            if (!std.ascii.eqlIgnoreCase(name, "Content-Length")) continue;
+            const value = std.mem.trim(u8, line[sep + 1 ..], " \t");
+            return std.fmt.parseInt(usize, value, 10) catch null;
+        }
+        return null;
     }
 };

--- a/test/protocol_json_test.zig
+++ b/test/protocol_json_test.zig
@@ -8,6 +8,7 @@ test "basic info payload matches golden json" {
     try types.writeBasicInfoJson(&out.writer, .{
         .cpu_name = "CPU",
         .cpu_cores = 4,
+        .cpu_physical_cores = 2,
         .arch = "amd64",
         .os = "linux",
         .kernel_version = "6.1.0",
@@ -19,7 +20,7 @@ test "basic info payload matches golden json" {
         .gpu_name = "GPU",
         .virtualization = "kvm",
         .version = "0.0.1",
-    }, true);
+    }, true, true);
     try expectJsonEqual(out.written(), @embedFile("golden/basic_info.json"));
 }
 

--- a/test/task_test.zig
+++ b/test/task_test.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const config = @import("config");
+const local_http = @import("local_http.zig");
 const task = @import("protocol_task");
 
 test "empty exec task matches go result text" {
@@ -88,6 +90,66 @@ test "utc timestamp formats as unsigned rfc3339" {
     const text = try task.utcFromTimestamp(std.testing.allocator, 0);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings("1970-01-01T00:00:00Z", text);
+}
+
+test "uploadExecResult keeps v1 task result upload for v2 sessions" {
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    const responses = [_][]const u8{response};
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+    errdefer server.join() catch unreachable;
+
+    const endpoint = try server.url(std.testing.allocator, "");
+    defer std.testing.allocator.free(endpoint);
+    const cfg = config.Config{
+        .endpoint = endpoint,
+        .token = "tok",
+        .disable_compression = true,
+        .disable_web_ssh = true,
+        .max_retries = 0,
+    };
+    try task.uploadExecResult(std.testing.allocator, cfg, 2, "task-1", "ignored");
+
+    var completed = try server.finish();
+    defer completed.deinit();
+
+    try std.testing.expectEqual(@as(usize, 1), completed.requests.len);
+    const request = completed.requests[0];
+    try std.testing.expectEqualStrings("POST /api/clients/task/result?token=tok HTTP/1.1", request.requestLine());
+    try std.testing.expectEqualStrings("komari-zig-agent", request.header("User-Agent").?);
+    try std.testing.expectEqualStrings("application/json", request.header("Content-Type").?);
+    try std.testing.expect(request.header("Content-Encoding") == null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, request.body, .{});
+    defer parsed.deinit();
+    const root = try expectObject(parsed.value);
+    try expectStringField(root, "task_id", "task-1");
+    try expectStringField(root, "result", "Remote control is disabled.");
+    try expectIntField(root, "exit_code", -1);
+    const finished_at = root.get("finished_at") orelse return error.TestUnexpectedResult;
+    if (finished_at != .string) return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.endsWith(u8, finished_at.string, "Z"));
+}
+
+fn expectObject(value: std.json.Value) !std.json.ObjectMap {
+    if (value != .object) return error.TestUnexpectedResult;
+    return value.object;
+}
+
+fn expectObjectValue(object: std.json.ObjectMap, key: []const u8) !std.json.ObjectMap {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    return expectObject(value);
+}
+
+fn expectStringField(object: std.json.ObjectMap, key: []const u8, expected: []const u8) !void {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    if (value != .string) return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(expected, value.string);
+}
+
+fn expectIntField(object: std.json.ObjectMap, key: []const u8, expected: i64) !void {
+    const value = object.get(key) orelse return error.TestUnexpectedResult;
+    if (value != .integer) return error.TestUnexpectedResult;
+    try std.testing.expectEqual(expected, value.integer);
 }
 
 fn stdoutRunner(allocator: std.mem.Allocator, env: *std.process.Environ.Map, command: []const u8) !std.process.RunResult {

--- a/test/v2_state_test.zig
+++ b/test/v2_state_test.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const v2_state = @import("protocol_v2_state");
+
+test "requested protocol version normalizes to v1 or v2" {
+    v2_state.initRequestedProtocolVersion(0);
+    try std.testing.expectEqual(@as(i32, 1), v2_state.requestedProtocolVersion());
+
+    v2_state.initRequestedProtocolVersion(1);
+    try std.testing.expectEqual(@as(i32, 1), v2_state.requestedProtocolVersion());
+
+    v2_state.initRequestedProtocolVersion(2);
+    try std.testing.expectEqual(@as(i32, 2), v2_state.requestedProtocolVersion());
+}
+
+test "v2 protocol failures fall back after three attempts" {
+    v2_state.initRequestedProtocolVersion(2);
+    v2_state.resetConnectionProtocolVersion();
+
+    const first = v2_state.noteV2AttemptResult(2, error.InvalidV2Response);
+    try std.testing.expectEqual(@as(u32, 1), first.failures);
+    try std.testing.expect(!first.fallback);
+
+    const second = v2_state.noteV2AttemptResult(2, error.InvalidV2EventResult);
+    try std.testing.expectEqual(@as(u32, 2), second.failures);
+    try std.testing.expect(!second.fallback);
+
+    const third = v2_state.noteV2AttemptResult(2, error.HttpStatusNotOk);
+    try std.testing.expectEqual(@as(u32, 3), third.failures);
+    try std.testing.expect(third.fallback);
+}
+
+test "non protocol errors do not count toward v2 fallback" {
+    v2_state.initRequestedProtocolVersion(2);
+    v2_state.resetConnectionProtocolVersion();
+
+    const result = v2_state.noteV2AttemptResult(2, error.ConnectionRefused);
+    try std.testing.expectEqual(@as(u32, 0), result.failures);
+    try std.testing.expect(!result.fallback);
+
+    const followup = v2_state.noteV2AttemptResult(2, error.InvalidV2Response);
+    try std.testing.expectEqual(@as(u32, 1), followup.failures);
+    try std.testing.expect(!followup.fallback);
+}
+
+test "successful v2 attempt resets failure count" {
+    v2_state.initRequestedProtocolVersion(2);
+    v2_state.resetConnectionProtocolVersion();
+
+    _ = v2_state.noteV2AttemptResult(2, error.InvalidV2Response);
+    _ = v2_state.noteV2AttemptResult(2, error.InvalidV2Response);
+
+    const success = v2_state.noteV2AttemptResult(2, null);
+    try std.testing.expectEqual(@as(u32, 0), success.failures);
+    try std.testing.expect(!success.fallback);
+
+    const next = v2_state.noteV2AttemptResult(2, error.InvalidV2Response);
+    try std.testing.expectEqual(@as(u32, 1), next.failures);
+    try std.testing.expect(!next.fallback);
+}

--- a/test/ws_message_test.zig
+++ b/test/ws_message_test.zig
@@ -66,6 +66,28 @@ test "websocket leaky ping parser accepts numeric task id" {
     try std.testing.expectEqualStrings("example.com:443", msg.ping_target);
 }
 
+test "v2 websocket ping message parses from params" {
+    const msg = try report_ws.parseServerMessage(
+        std.testing.allocator,
+        "{\"jsonrpc\":\"2.0\",\"method\":\"agent.ping\",\"params\":{\"ping_task_id\":11,\"ping_type\":\"http\",\"ping_target\":\"example.com\"}}",
+    );
+    defer msg.deinit(std.testing.allocator);
+    try std.testing.expectEqual(report_ws.ServerMessageKind.ping, msg.kind);
+    try std.testing.expectEqual(@as(u64, 11), msg.ping_task_id);
+    try std.testing.expectEqualStrings("http", msg.ping_type);
+    try std.testing.expectEqualStrings("example.com", msg.ping_target);
+}
+
+test "v2 websocket terminal message parses from params" {
+    const msg = try report_ws.parseServerMessage(
+        std.testing.allocator,
+        "{\"jsonrpc\":\"2.0\",\"method\":\"agent.terminal.request\",\"params\":{\"request_id\":\"term-v2\"}}",
+    );
+    defer msg.deinit(std.testing.allocator);
+    try std.testing.expectEqual(report_ws.ServerMessageKind.terminal, msg.kind);
+    try std.testing.expectEqualStrings("term-v2", msg.request_id);
+}
+
 fn sliceInside(container: []const u8, slice: []const u8) bool {
     const start = @intFromPtr(container.ptr);
     const end = start + container.len;


### PR DESCRIPTION
## Summary
- sync upstream Komari v2 JSON-RPC report/basicInfo/pull/ping protocol behavior
- add v2 POST fallback/recovery state handling and protocol downgrade support
- add mock/replay E2E coverage for v2 websocket, POST fallback, and recovery flows
- include recent upstream platform/task/terminal compatibility fixes

## Local validation
- zig build test
- zig build -Dtarget=x86_64-linux-gnu -Doptimize=ReleaseSmall -Dversion=dev
- zig build -Doptimize=ReleaseSmall -Dversion=dev
- ssh ccs2 python3 mock_komari_v2_e2e.py ws ./komari-agent --terminal --timeout 35
- ssh ccs2 python3 mock_komari_v2_e2e.py post-fallback ./komari-agent --timeout 35
- ssh ccs2 python3 mock_komari_v2_e2e.py post-recover ./komari-agent --timeout 45