### PR TITLE
fix: use runtime io for subprocess spawning

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -11,6 +11,10 @@ const format = @import("compat/format.zig");
 /// Compatibility facade kept stable while internals move to Zig 0.16 modules.
 pub const Mutex = sync.Mutex;
 
+pub fn io() std.Io {
+    return runtime.io();
+}
+
 pub fn currentEnvMap(allocator: std.mem.Allocator) !std.process.Environ.Map {
     return runtime.currentEnvMap(allocator);
 }

--- a/src/compat/process.zig
+++ b/src/compat/process.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const runtime = @import("runtime");
 const windows = std.os.windows;
 
 /// Process spawning helpers with bounded stdout capture.
@@ -25,18 +26,19 @@ pub fn runOutputIgnoreStderr(
     environ_map: ?*const std.process.Environ.Map,
     stdout_limit: usize,
 ) !RunOutputResult {
-    var child = try std.process.spawn(std.Options.debug_io, .{
+    const io = runtime.io();
+    var child = try std.process.spawn(io, .{
         .argv = argv,
         .environ_map = environ_map,
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .ignore,
     });
-    defer child.kill(std.Options.debug_io);
+    defer child.kill(io);
 
     const stdout_file = child.stdout orelse return error.CommandFailed;
     var reader_buf: [4096]u8 = undefined;
-    var reader = stdout_file.reader(std.Options.debug_io, &reader_buf);
+    var reader = stdout_file.reader(io, &reader_buf);
     var out = std.Io.Writer.Allocating.init(allocator);
     errdefer out.deinit();
     var total: usize = 0;
@@ -50,7 +52,7 @@ pub fn runOutputIgnoreStderr(
     }
 
     return .{
-        .term = try child.wait(std.Options.debug_io),
+        .term = try child.wait(io),
         .stdout = try out.toOwnedSlice(),
     };
 }
@@ -66,15 +68,16 @@ pub fn spawnWindowsPiped(allocator: std.mem.Allocator, argv: []const []const u8,
 }
 
 pub fn runIgnoreOutput(argv: []const []const u8, environ_map: ?*const std.process.Environ.Map) !std.process.Child.Term {
-    var child = try std.process.spawn(std.Options.debug_io, .{
+    const io = runtime.io();
+    var child = try std.process.spawn(io, .{
         .argv = argv,
         .environ_map = environ_map,
         .stdin = .ignore,
         .stdout = .ignore,
         .stderr = .ignore,
     });
-    defer child.kill(std.Options.debug_io);
-    return child.wait(std.Options.debug_io);
+    defer child.kill(io);
+    return child.wait(io);
 }
 
 const HANDLE_FLAG_INHERIT: windows.DWORD = 0x00000001;

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1,11 +1,23 @@
 const std = @import("std");
 
 var process_environ: std.process.Environ = .empty;
+var process_io: std.Io.Threaded = .init_single_threaded;
+var process_io_initialized = std.atomic.Value(bool).init(false);
 
 /// Captures process data supplied by Zig 0.16 startup when using
 /// `std.process.Init.Minimal`.
 pub fn init(minimal: std.process.Init.Minimal) void {
     process_environ = minimal.environ;
+    process_io = .init(std.heap.page_allocator, .{
+        .argv0 = .init(minimal.args),
+        .environ = minimal.environ,
+    });
+    process_io_initialized.store(true, .release);
+}
+
+pub fn io() std.Io {
+    if (process_io_initialized.load(.acquire)) return process_io.io();
+    return std.Options.debug_io;
 }
 
 pub fn currentEnvMap(allocator: std.mem.Allocator) !std.process.Environ.Map {

--- a/src/terminal/terminal.zig
+++ b/src/terminal/terminal.zig
@@ -326,7 +326,8 @@ fn startPipeFallback(allocator: std.mem.Allocator) !ShellSession {
     const cwd = try terminalCwdAlloc(allocator);
     defer allocator.free(cwd);
     const argv = &.{ "script", "-q", "-c", shell, "/dev/null" };
-    var child = try std.process.spawn(std.Options.debug_io, .{
+    const io = compat.io();
+    var child = try std.process.spawn(io, .{
         .argv = argv,
         .cwd = .{ .path = cwd },
         .environ_map = env,
@@ -335,7 +336,7 @@ fn startPipeFallback(allocator: std.mem.Allocator) !ShellSession {
         .stderr = .ignore,
     });
     if (child.stdin == null or child.stdout == null) {
-        child.kill(std.Options.debug_io);
+        child.kill(io);
         return error.ShellPipeFailed;
     }
     return .{


### PR DESCRIPTION
Fixes #11.

This fixes subprocess spawning under Zig `Init.Minimal`: production paths now use runtime IO backed by the page allocator instead of the default debug IO, avoiding `OutOfMemory` before executing commands like `ip -o addr show scope global`.

Validation:
- `zig build test`
- `zig build -Doptimize=ReleaseSmall -Dversion=dev`
- `zig build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseSmall -Dversion=dev`
