### PR TITLE
fix: avoid private container IP startup reports

### DIFF
--- a/src/basic_info_flow.zig
+++ b/src/basic_info_flow.zig
@@ -16,6 +16,17 @@ pub fn shouldStartBackgroundLoopImmediately(outcome: ForegroundUploadOutcome) bo
     return outcome == .deferred;
 }
 
+/// Decides whether a synchronous upload must wait for the public IPv4 refresh.
+pub fn shouldDeferForPublicIPv4(
+    allow_external_ip_lookup: bool,
+    get_ip_addr_from_nic: bool,
+    custom_ipv4: []const u8,
+    current_is_public: bool,
+) bool {
+    if (allow_external_ip_lookup or get_ip_addr_from_nic or custom_ipv4.len != 0) return false;
+    return !current_is_public;
+}
+
 pub fn contextLabel(context: UploadContext) []const u8 {
     return switch (context) {
         .startup => "startup",

--- a/src/main.zig
+++ b/src/main.zig
@@ -206,8 +206,13 @@ fn uploadBasicInfoOnce(allocator: std.mem.Allocator, cfg: config.Config, allow_e
     var info = try provider.basicInfo(scratch);
     debug.log("basic info collected: local_ipv4={s} local_ipv6={s}", .{ info.ipv4, info.ipv6 });
     try applyIpConfig(scratch, cfg, &info, allow_external_ip_lookup);
-    if (!allow_external_ip_lookup and info.ipv4.len == 0) {
-        debug.log("deferring foreground basic info upload until public IP refresh because IPv4 is empty", .{});
+    if (basic_info_flow.shouldDeferForPublicIPv4(
+        allow_external_ip_lookup,
+        cfg.get_ip_addr_from_nic,
+        cfg.custom_ipv4,
+        ip.isPubliclyRoutableIPv4(info.ipv4),
+    )) {
+        debug.log("deferring foreground basic info upload until public IP refresh because IPv4 is not publicly routable: {s}", .{info.ipv4});
         return error.BasicInfoDeferredUntilPublicIp;
     }
     const info_json = try basic_info.allocBasicInfoJson(scratch, info, true, true);

--- a/src/protocol/ip.zig
+++ b/src/protocol/ip.zig
@@ -38,6 +38,39 @@ pub fn shouldLookupExternalAddress(existing: []const u8, custom: []const u8, all
     return allow_external_lookup and custom.len == 0;
 }
 
+/// Returns true only for IPv4 addresses suitable for public node identity.
+pub fn isPubliclyRoutableIPv4(value: []const u8) bool {
+    const octets = parseIPv4Octets(value) orelse return false;
+    const a = octets[0];
+    const b = octets[1];
+    const c = octets[2];
+
+    if (a == 0 or a == 10 or a == 127) return false;
+    if (a == 100 and b >= 64 and b <= 127) return false;
+    if (a == 169 and b == 254) return false;
+    if (a == 172 and b >= 16 and b <= 31) return false;
+    if (a == 192 and b == 0 and (c == 0 or c == 2)) return false;
+    if (a == 192 and b == 88 and c == 99) return false;
+    if (a == 192 and b == 168) return false;
+    if (a == 198 and (b == 18 or b == 19)) return false;
+    if (a == 198 and b == 51 and c == 100) return false;
+    if (a == 203 and b == 0 and c == 113) return false;
+    if (a >= 224) return false;
+    return true;
+}
+
+fn parseIPv4Octets(value: []const u8) ?[4]u8 {
+    var octets: [4]u8 = undefined;
+    var parts = std.mem.splitScalar(u8, value, '.');
+    var index: usize = 0;
+    while (parts.next()) |part| {
+        if (index >= octets.len or part.len == 0) return null;
+        octets[index] = std.fmt.parseInt(u8, part, 10) catch return null;
+        index += 1;
+    }
+    return if (index == octets.len) octets else null;
+}
+
 fn getAddressFromApis(
     allocator: std.mem.Allocator,
     cfg: anytype,

--- a/test/basic_info_flow_test.zig
+++ b/test/basic_info_flow_test.zig
@@ -33,6 +33,17 @@ test "foreground upload deferral is the only case that restarts background loop 
     try std.testing.expect(!flow.shouldStartBackgroundLoopImmediately(.{ .failure = error.Timeout }));
 }
 
+test "automatic foreground upload defers non-public IPv4" {
+    try std.testing.expect(flow.shouldDeferForPublicIPv4(false, false, "", false));
+    try std.testing.expect(!flow.shouldDeferForPublicIPv4(false, false, "", true));
+}
+
+test "explicit IPv4 modes preserve user-selected addresses" {
+    try std.testing.expect(!flow.shouldDeferForPublicIPv4(false, false, "10.0.0.5", false));
+    try std.testing.expect(!flow.shouldDeferForPublicIPv4(false, true, "", false));
+    try std.testing.expect(!flow.shouldDeferForPublicIPv4(true, false, "", false));
+}
+
 test "foreground upload failure during startup is tolerated and logged" {
     var out = std.Io.Writer.Allocating.init(std.testing.allocator);
     defer out.deinit();

--- a/test/coverage_test.zig
+++ b/test/coverage_test.zig
@@ -23,3 +23,14 @@ test "coverage external lookup runs in automatic mode unless explicitly overridd
     try std.testing.expect(!ip.shouldLookupExternalAddress("", "198.51.100.8", true));
     try std.testing.expect(!ip.shouldLookupExternalAddress("", "", false));
 }
+
+test "coverage classifies public and non-public IPv4 addresses" {
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("1.1.1.1"));
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("198.20.0.1"));
+    try std.testing.expect(!ip.isPubliclyRoutableIPv4(""));
+    try std.testing.expect(!ip.isPubliclyRoutableIPv4("10.91.0.28"));
+    try std.testing.expect(!ip.isPubliclyRoutableIPv4("100.64.0.1"));
+    try std.testing.expect(!ip.isPubliclyRoutableIPv4("192.168.1.1"));
+    try std.testing.expect(!ip.isPubliclyRoutableIPv4("203.0.113.1"));
+    try std.testing.expect(!ip.isPubliclyRoutableIPv4("255.255.255.255"));
+}

--- a/test/ip_extract_test.zig
+++ b/test/ip_extract_test.zig
@@ -23,3 +23,23 @@ test "external lookup runs in automatic mode unless explicitly overridden" {
     try std.testing.expect(!ip.shouldLookupExternalAddress("", "198.51.100.8", true));
     try std.testing.expect(!ip.shouldLookupExternalAddress("", "", false));
 }
+
+test "classifies publicly routable IPv4 addresses" {
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("1.1.1.1"));
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("8.8.8.8"));
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("192.1.1.1"));
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("198.20.0.1"));
+    try std.testing.expect(ip.isPubliclyRoutableIPv4("203.0.114.1"));
+}
+
+test "rejects private shared and special-use IPv4 addresses" {
+    const rejected = [_][]const u8{
+        "",           "not-an-ip",       "1.2.3",        "1.2.3.4.5",
+        "0.0.0.0",    "10.91.0.28",      "100.64.0.1",   "100.127.255.254",
+        "127.0.0.1",  "169.254.1.1",     "172.16.0.1",   "172.31.255.254",
+        "192.0.0.1",  "192.0.2.1",       "192.88.99.1",  "192.168.1.1",
+        "198.18.0.1", "198.19.255.254",  "198.51.100.1", "203.0.113.1",
+        "224.0.0.1",  "239.255.255.255", "240.0.0.1",    "255.255.255.255",
+    };
+    for (rejected) |value| try std.testing.expect(!ip.isPubliclyRoutableIPv4(value));
+}


### PR DESCRIPTION
## Summary

Fixes #17.

- Classify private, CGNAT, link-local, loopback, documentation, benchmark, multicast, and reserved IPv4 ranges as unsuitable for automatic public node identity.
- Defer the synchronous startup/reconnect basic-info upload when automatic IP detection only found a non-public IPv4 address.
- Reuse the existing deferred-upload path so the background public-IP lookup runs immediately instead of waiting the default five-minute basic-info interval.
- Preserve explicit `--custom-ipv4` and `--get-ip-addr-from-nic` behavior.

## Root cause

Startup calls the foreground basic-info upload with external lookup disabled. The previous guard only deferred when IPv4 was empty. A container address such as `10.91.0.28` was non-empty, so it was uploaded immediately and shown on the dashboard. The public-IP background refresh only ran after the normal five-minute interval because the foreground upload was considered successful.

## Validation

- `zig build test`
- `zig build -Doptimize=ReleaseSmall -Dversion=issue17-test`
- `python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --cf --no-exec`
- `python3 scripts/mock_komari_smoke.py zig-out/bin/komari-agent --max-basic-info-seconds 15`

The mock panel smoke completed with one basic-info upload, one report, and one task result in 0.101 seconds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to distinguish publicly routable IPv4 addresses from private, reserved, invalid, and special-use addresses.
  * Foreground basic-information uploads now defer when the detected IPv4 address is not publicly routable and no explicit address source is configured.
  * Configured custom IPv4 addresses and supported automatic lookup options continue without deferral.

* **Tests**
  * Added coverage for IPv4 classification and upload deferral scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->