### PR TITLE
fix: preserve monthly traffic across restarts

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -92,12 +92,15 @@ pub fn main(init: std.process.Init.Minimal) !void {
     }
 
     if (cfg.month_rotate != 0) {
-        netstatic.startOrContinue() catch |err| try stdout.print("Failed to start netstatic monitoring: {s}\n", .{@errorName(err)});
-        const nics = provider.interfaceList(allocator, cfg.include_nics, cfg.exclude_nics) catch &.{};
-        netstatic.setNewConfig(.{ .nics = nics }) catch |err| try stdout.print("Failed to set netstatic config: {s}\n", .{@errorName(err)});
-        netstatic_active.store(true, .release);
+        if (netstatic.startOrContinue()) |_| {
+            const nics = provider.interfaceList(allocator, cfg.include_nics, cfg.exclude_nics) catch &.{};
+            netstatic.setNewConfig(.{ .nics = nics }) catch |err| try stdout.print("Failed to set netstatic config: {s}\n", .{@errorName(err)});
+            netstatic_active.store(true, .release);
+        } else |err| {
+            try stdout.print("Failed to start netstatic monitoring: {s}; existing state file was not modified\n", .{@errorName(err)});
+        }
     }
-    defer if (cfg.month_rotate != 0) netstatic.stop() catch {};
+    defer if (netstatic_active.load(.acquire)) netstatic.stop() catch {};
 
     if (!cfg.disable_auto_update) {
         const has_pending_update = update.hasPendingUpdate(allocator);

--- a/src/report/netstatic.zig
+++ b/src/report/netstatic.zig
@@ -103,15 +103,14 @@ var runtime: ?*Runtime = null;
 pub fn startOrContinue() !void {
     const allocator = std.heap.page_allocator;
     const rt = try getRuntime(allocator);
-    rt.mutex.lock();
-    if (rt.running) {
-        rt.mutex.unlock();
-        return;
+    {
+        rt.mutex.lock();
+        defer rt.mutex.unlock();
+        if (rt.running) return;
+        try loadFromFileLocked(rt);
+        rt.running = true;
+        rt.stop_requested = false;
     }
-    try loadFromFileLocked(rt);
-    rt.running = true;
-    rt.stop_requested = false;
-    rt.mutex.unlock();
 
     const sampler = try std.Thread.spawn(.{ .stack_size = 256 * 1024 }, sampleLoop, .{rt});
     sampler.detach();
@@ -478,12 +477,9 @@ fn loadFromFileLocked(rt: *Runtime) !void {
 }
 
 fn parseNetStaticJsonInto(rt: *Runtime, bytes: []const u8) !void {
-    var parsed = std.json.parseFromSlice(std.json.Value, rt.allocator, bytes, .{}) catch {
-        std.Io.Dir.cwd().rename(saveFilePath(), std.Io.Dir.cwd(), "net_static.json.bak", std.Options.debug_io) catch {};
-        return;
-    };
+    var parsed = try parsePersistedJson(rt.allocator, bytes);
     defer parsed.deinit();
-    if (parsed.value != .object) return;
+    if (parsed.value != .object) return error.InvalidNetStaticState;
     if (parsed.value.object.get("config")) |cfg_value| {
         if (cfg_value == .object) {
             rt.config.data_preserve_day = jsonFloat(cfg_value.object.get("data_preserve_day")) orelse rt.config.data_preserve_day;
@@ -509,6 +505,21 @@ fn parseNetStaticJsonInto(rt: *Runtime, bytes: []const u8) !void {
     }
 }
 
+fn parsePersistedJson(allocator: std.mem.Allocator, bytes: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch {
+        if (!std.mem.endsWith(u8, bytes, "}}}")) return error.InvalidNetStaticState;
+        return std.json.parseFromSlice(std.json.Value, allocator, bytes[0 .. bytes.len - 1], .{}) catch error.InvalidNetStaticState;
+    };
+}
+
+pub fn validatePersistedState(allocator: std.mem.Allocator, bytes: []const u8) !void {
+    var parsed = try parsePersistedJson(allocator, bytes);
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidNetStaticState;
+    const interfaces = parsed.value.object.get("interfaces") orelse return error.InvalidNetStaticState;
+    if (interfaces != .object) return error.InvalidNetStaticState;
+}
+
 fn saveToFileLocked(rt: *Runtime) !void {
     var writer = std.Io.Writer.Allocating.init(rt.allocator);
     defer writer.deinit();
@@ -530,7 +541,7 @@ fn saveToFileLocked(rt: *Runtime) !void {
         if (i != 0) try writer.writer.writeByte(',');
         try writer.writer.print("{f}", .{std.json.fmt(nic, .{})});
     }
-    try writer.writer.writeAll("]}}}");
+    try writer.writer.writeAll("]}}");
     const bytes = try writer.toOwnedSlice();
     defer rt.allocator.free(bytes);
     const tmp = "net_static.json.tmp";

--- a/test/netstatic_test.zig
+++ b/test/netstatic_test.zig
@@ -33,3 +33,17 @@ test "store json round trips baseline counters" {
     try std.testing.expectEqual(@as(u64, 456), parsed.up);
     try std.testing.expectEqual(@as(u64, 789), parsed.down);
 }
+
+test "invalid persisted traffic data is rejected" {
+    try std.testing.expectError(error.InvalidNetStaticState, netstatic.validatePersistedState(std.testing.allocator, "{\"interfaces\":"));
+}
+
+test "legacy persisted traffic with one extra closing brace remains readable" {
+    const legacy = "{\"interfaces\":{},\"config\":{\"data_preserve_day\":31}}}";
+    try netstatic.validatePersistedState(std.testing.allocator, legacy);
+}
+
+test "valid persisted traffic remains readable" {
+    const valid = "{\"interfaces\":{},\"config\":{\"data_preserve_day\":31}}";
+    try netstatic.validatePersistedState(std.testing.allocator, valid);
+}


### PR DESCRIPTION
## Summary

Fixes #18.

- Remove the extra closing brace written to `net_static.json`.
- Read the exact legacy v0.1.42 format with one extra trailing brace so existing traffic history remains usable.
- Return load errors instead of treating invalid JSON as an empty successful load.
- Configure and stop netstatic only after it started successfully, so a load failure cannot overwrite the existing state file with empty data.
- Release the netstatic mutex on startup errors.

## Root cause

`saveToFileLocked()` ended persisted JSON with `]}}}` instead of `]}}`. The reporter's primary and backup files both fail JSON validation with `Extra data` at the final byte, and the captured tail confirms the extra `}`.

On restart, the parser treated that failure as success after renaming the old file. `main` then called `setNewConfig()`, which immediately wrote an empty `interfaces` map. This turned a one-byte serialization error into visible traffic loss.

## Validation

- `zig build test`
- `zig build -Doptimize=ReleaseSmall -Dversion=issue18-test`
- `python3 scripts/mock_komari_business_e2e.py panel zig-out/bin/komari-agent --cf --no-exec`
- `python3 scripts/mock_komari_smoke.py zig-out/bin/komari-agent --max-basic-info-seconds 15`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved netstatic monitoring startup and shutdown handling when configuration is enabled.
  * Prevented invalid persisted monitoring state from being silently accepted or applied.
  * Corrected the format of saved monitoring state data.
  * Added validation for malformed and legacy persisted state files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->