### PR TITLE
fix: support socket timeouts on 32-bit MIPS Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,9 +351,11 @@ jobs:
           chmod +x ./komari-agent
           if [ "${{ matrix.runner }}" = "direct" ]; then
             ./komari-agent --show-warning
+            ./komari-agent socket-timeout-smoke
           else
             command -v "${{ matrix.runner }}"
             "${{ matrix.runner }}" ./komari-agent --show-warning
+            "${{ matrix.runner }}" ./komari-agent socket-timeout-smoke
           fi
 
   build:

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,7 @@ pub const Command = enum {
     run,
     list_disk,
     check_mem,
+    socket_timeout_smoke,
 };
 
 pub const Config = struct {
@@ -146,6 +147,8 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const []const u8) !Config
             cfg.command = .list_disk;
         } else if (std.mem.eql(u8, arg, "check-mem")) {
             cfg.command = .check_mem;
+        } else if (std.mem.eql(u8, arg, "socket-timeout-smoke")) {
+            cfg.command = .socket_timeout_smoke;
         } else if (optionValue(arg, "--token")) |v| {
             cfg.token = try allocator.dupe(u8, v);
         } else if (optionValue(arg, "--endpoint")) |v| {

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,7 @@ const common = @import("platform/common.zig");
 const provider = @import("platform/provider.zig");
 const ip = @import("protocol/ip.zig");
 const netstatic = @import("report_netstatic");
+const net = @import("net");
 const ping = @import("protocol/ping.zig");
 const report_ws = @import("protocol/report_ws.zig");
 const v2_state = @import("protocol/v2_state.zig");
@@ -73,6 +74,11 @@ pub fn main(init: std.process.Init.Minimal) !void {
         var stdout = compat.fileWriter(std.Io.File.stdout(), &stdout_buf);
         defer stdout.flush() catch {};
         try provider.printMemoryCheck(allocator, &stdout, cfg.memory_include_cache, cfg.memory_report_raw_used);
+        return;
+    }
+
+    if (cfg.command == .socket_timeout_smoke) {
+        try net.socketTimeoutSmoke(30_000);
         return;
     }
 

--- a/src/net.zig
+++ b/src/net.zig
@@ -5,6 +5,11 @@ pub const net = std.Io.net;
 pub const Address = net.IpAddress;
 pub const Stream = net.Stream;
 
+const LinuxSocketTimeval = extern struct {
+    sec: c_long,
+    usec: c_long,
+};
+
 pub fn parseIp(text: []const u8, p: u16) !Address {
     return Address.parse(text, p);
 }
@@ -169,12 +174,41 @@ fn connectWithTimeoutLinux(addr: Address, timeout_ms: u64) !Stream {
 fn setStreamTimeouts(stream: Stream, timeout_ms: u64) !void {
     switch (builtin.os.tag) {
         .windows => return,
+        .linux => {
+            // SO_{RCV,SND}TIMEO use the kernel's legacy long/long ABI on
+            // 32-bit Linux. Zig 0.16's std.posix.timeval is time64 there and
+            // is rejected with EDOM (TimeoutTooBig), notably on MIPS/OpenWrt.
+            const tv = timeoutToLinuxSocketTimeval(timeout_ms);
+            try std.posix.setsockopt(stream.socket.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&tv));
+            try std.posix.setsockopt(stream.socket.handle, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, std.mem.asBytes(&tv));
+        },
         else => {
             const tv = timeoutToTimeval(timeout_ms);
             try std.posix.setsockopt(stream.socket.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&tv));
             try std.posix.setsockopt(stream.socket.handle, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, std.mem.asBytes(&tv));
         },
     }
+}
+
+fn timeoutToLinuxSocketTimeval(timeout_ms: u64) LinuxSocketTimeval {
+    const seconds = timeout_ms / 1000;
+    const microseconds = (timeout_ms % 1000) * 1000;
+    return .{
+        .sec = std.math.cast(c_long, seconds) orelse std.math.maxInt(c_long),
+        .usec = @intCast(microseconds),
+    };
+}
+
+pub fn socketTimeoutSmoke(timeout_ms: u64) !void {
+    if (builtin.os.tag != .linux) return;
+    const fd = try socketLinux(std.posix.AF.INET, std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC, std.posix.IPPROTO.TCP);
+    defer _ = std.os.linux.close(fd);
+    const stream: Stream = .{ .socket = .{ .handle = fd, .address = initIp4(.{ 127, 0, 0, 1 }, 0) } };
+    try setStreamTimeouts(stream, timeout_ms);
+}
+
+pub fn linuxSocketTimevalSize() usize {
+    return @sizeOf(LinuxSocketTimeval);
 }
 
 fn timeoutToTimeval(timeout_ms: u64) std.posix.timeval {

--- a/test/config_test.zig
+++ b/test/config_test.zig
@@ -220,6 +220,15 @@ test "check-mem subcommand is recognized" {
     try std.testing.expectEqual(config.Command.check_mem, cfg.command);
 }
 
+test "socket-timeout-smoke subcommand is recognized" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const args = [_][]const u8{ "komari-agent", "socket-timeout-smoke" };
+    const cfg = try config.parseArgs(arena.allocator(), &args);
+    try std.testing.expectEqual(config.Command.socket_timeout_smoke, cfg.command);
+}
+
 test "unknown flags are ignored" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/test/raw_conn_test.zig
+++ b/test/raw_conn_test.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const net = @import("net");
 const raw_conn = @import("protocol_raw_conn");
 
 test "tls ca bundle storage is per connection" {
@@ -11,4 +13,9 @@ test "tls ca bundle storage is per connection" {
 
 test "tls ca bundle can be rescanned without global cache" {
     try raw_conn.rescanCaBundleForTest();
+}
+
+test "linux socket timeout ABI follows kernel long width" {
+    if (builtin.os.tag != .linux) return;
+    try std.testing.expectEqual(@sizeOf(c_long) * 2, net.linuxSocketTimevalSize());
 }


### PR DESCRIPTION
## Summary

- use the kernel `long`/`long` socket timeout ABI on Linux instead of Zig 0.16's incompatible 32-bit `std.posix.timeval`
- add an internal socket timeout smoke command and run it across the existing Linux architecture QEMU matrix
- add CLI parsing and timeout ABI layout regression tests

## Root cause

On `mipsel-linux-musleabi`, Zig 0.16's `std.posix.timeval` is 16 bytes while Linux MIPS `SO_RCVTIMEO` / `SO_SNDTIMEO` legacy options expect two 32-bit `long` values (8 bytes). Passing 16 bytes makes `setsockopt` fail (`EINVAL` in QEMU and reported as `EDOM` / `TimeoutTooBig` on the user's OpenWrt kernel).

System-call comparison:

- before: `setsockopt(..., SO_RCVTIMEO, ..., 16) = -1 EINVAL`
- after: `setsockopt(..., SO_RCVTIMEO, ..., 8) = 0` and `SO_SNDTIMEO = 0`

## Verification

- `zig fmt --check ...`
- `zig build test`
- native `ReleaseSmall` build and `socket-timeout-smoke`
- MIPSel `ReleaseSmall` build and QEMU execution of `socket-timeout-smoke`
- all 11 Linux release targets cross-compiled
- all 4 FreeBSD, 2 macOS, and 3 Windows release targets cross-compiled

Closes #21
