### PR TITLE
fix: avoid Docker disk double counting with os-release bind mount

### DIFF
--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -1297,6 +1297,7 @@ pub fn diskDeviceKey(device: []const u8, fstype: []const u8) []const u8 {
 pub fn isPhysicalMount(mountpoint_raw: []const u8, fstype_raw: []const u8, device: []const u8) bool {
     if (std.mem.eql(u8, mountpoint_raw, "/")) return true;
     const mountpoint = mountpoint_raw;
+    if (std.mem.eql(u8, mountpoint, "/usr/lib/os-release")) return false;
     const excluded_mounts = [_][]const u8{
         "/tmp",
         "/var/tmp",
@@ -1309,7 +1310,6 @@ pub fn isPhysicalMount(mountpoint_raw: []const u8, fstype_raw: []const u8, devic
         "/sys/fs/cgroup",
         "/etc/resolv.conf",
         "/etc/host",
-        "/usr/lib/os-release",
         "/nix/store",
     };
     for (&excluded_mounts) |prefix| {

--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -1309,6 +1309,7 @@ pub fn isPhysicalMount(mountpoint_raw: []const u8, fstype_raw: []const u8, devic
         "/sys/fs/cgroup",
         "/etc/resolv.conf",
         "/etc/host",
+        "/usr/lib/os-release",
         "/nix/store",
     };
     for (&excluded_mounts) |prefix| {

--- a/test/disk_filter_test.zig
+++ b/test/disk_filter_test.zig
@@ -6,6 +6,7 @@ test "physical disk filter keeps root and excludes pseudo filesystems" {
     try std.testing.expect(!linux.isPhysicalMount("/proc", "proc", "proc"));
     try std.testing.expect(!linux.isPhysicalMount("/sys/fs/cgroup", "cgroup2", "cgroup2"));
     try std.testing.expect(!linux.isPhysicalMount("/var/lib/docker/overlay2/x", "ext4", "/dev/sda1"));
+    try std.testing.expect(!linux.isPhysicalMount("/usr/lib/os-release", "ext4", "/dev/sda1"));
     try std.testing.expect(!linux.isPhysicalMount("/mnt/share", "nfs", "server:/share"));
     try std.testing.expect(!linux.isPhysicalMount("/snap/core", "squashfs", "/dev/loop0"));
     try std.testing.expect(linux.isPhysicalMount("/data", "ext4", "/dev/sdb1"));

--- a/test/disk_filter_test.zig
+++ b/test/disk_filter_test.zig
@@ -7,6 +7,8 @@ test "physical disk filter keeps root and excludes pseudo filesystems" {
     try std.testing.expect(!linux.isPhysicalMount("/sys/fs/cgroup", "cgroup2", "cgroup2"));
     try std.testing.expect(!linux.isPhysicalMount("/var/lib/docker/overlay2/x", "ext4", "/dev/sda1"));
     try std.testing.expect(!linux.isPhysicalMount("/usr/lib/os-release", "ext4", "/dev/sda1"));
+    try std.testing.expect(linux.isPhysicalMount("/usr/lib/os-release-backup", "ext4", "/dev/sdb1"));
+    try std.testing.expect(linux.isPhysicalMount("/usr/lib/os-release2", "ext4", "/dev/sdc1"));
     try std.testing.expect(!linux.isPhysicalMount("/mnt/share", "nfs", "server:/share"));
     try std.testing.expect(!linux.isPhysicalMount("/snap/core", "squashfs", "/dev/loop0"));
     try std.testing.expect(linux.isPhysicalMount("/data", "ext4", "/dev/sdb1"));


### PR DESCRIPTION
## Summary

- exclude Alpine's resolved `/usr/lib/os-release` bind mount from physical disk aggregation
- add a regression assertion for the Docker bind-mount path

## Root cause

The reported Compose setup mounts the host `/etc/os-release` into the Alpine-based Zig Agent image. Alpine's `/etc/os-release` is a symlink to `/usr/lib/os-release`, so Docker records the mount as:

```text
/dev/... /usr/lib/os-release ext4 ...
```

The agent already excludes `/etc/os-release`-style metadata mounts, but did not exclude the resolved `/usr/lib/os-release` path. It therefore counted both:

```text
/ (overlay)
/usr/lib/os-release (ext4)
```

Both report the host filesystem capacity, making disk totals approximately double.

## Reproduction

With the Issue #24 bind mounts and v0.1.44:

```text
Monitoring Mountpoints: [/usr/lib/os-release (ext4) / (overlay)]
```

With this fix:

```text
Monitoring Mountpoints: [/ (overlay)]
```

## Verification

- regression test fails on v0.1.44 before the fix
- `zig build test`
- `zig fmt --check src/platform/linux.zig test/disk_filter_test.zig`
- native ReleaseSmall build
- `x86_64-linux-musl` ReleaseSmall build
- Alpine container reproduction using the same `/sys`, `/proc`, and `/etc/os-release` bind mounts as Issue #24

Closes #24
