### PR TITLE
fix: exclude auto-discovery bind mount from disk totals

### DIFF
--- a/src/platform/linux.zig
+++ b/src/platform/linux.zig
@@ -1225,6 +1225,7 @@ pub fn isPhysicalMount(mountpoint_raw: []const u8, fstype_raw: []const u8, devic
     if (std.mem.eql(u8, mountpoint_raw, "/")) return true;
     const mountpoint = mountpoint_raw;
     if (std.mem.eql(u8, mountpoint, "/usr/lib/os-release")) return false;
+    if (std.mem.eql(u8, mountpoint, "/app/auto-discovery.json")) return false;
     const excluded_mounts = [_][]const u8{
         "/tmp",
         "/var/tmp",

--- a/test/disk_filter_test.zig
+++ b/test/disk_filter_test.zig
@@ -9,6 +9,8 @@ test "physical disk filter keeps root and excludes pseudo filesystems" {
     try std.testing.expect(!linux.isPhysicalMount("/usr/lib/os-release", "ext4", "/dev/sda1"));
     try std.testing.expect(linux.isPhysicalMount("/usr/lib/os-release-backup", "ext4", "/dev/sdb1"));
     try std.testing.expect(linux.isPhysicalMount("/usr/lib/os-release2", "ext4", "/dev/sdc1"));
+    try std.testing.expect(!linux.isPhysicalMount("/app/auto-discovery.json", "ext4", "/dev/sda1"));
+    try std.testing.expect(linux.isPhysicalMount("/app/auto-discovery.json.backup", "ext4", "/dev/sdb1"));
     try std.testing.expect(!linux.isPhysicalMount("/mnt/share", "nfs", "server:/share"));
     try std.testing.expect(!linux.isPhysicalMount("/snap/core", "squashfs", "/dev/loop0"));
     try std.testing.expect(linux.isPhysicalMount("/data", "ext4", "/dev/sdb1"));


### PR DESCRIPTION
## Root cause

In Docker, the mounted `/app/auto-discovery.json` configuration file is reported as an `ext4` mount from the host filesystem. The disk collector counted it together with the container root `overlay`, doubling the reported disk capacity.

## Change

- exclude the exact `/app/auto-discovery.json` bind-mount path from physical disk collection
- add regression coverage for the target path and a neighboring `.backup` path that must remain eligible

Fixes #24.