### PR TITLE
auto-discovery: refresh stale token; send Host with port

### DIFF
--- a/src/autodiscovery_test.zig
+++ b/src/autodiscovery_test.zig
@@ -42,9 +42,7 @@ test "stored auto discovery config owns duplicated strings" {
     defer arena.deinit();
 
     const owned = blk: {
-        const bytes = try std.testing.allocator.dupe(u8,
-            \{"uuid":"u2","token":"tok2"}
-        );
+        const bytes = try std.testing.allocator.dupe(u8, "{\"uuid\":\"u2\",\"token\":\"tok2\"}");
         defer std.testing.allocator.free(bytes);
         break :blk (try autodiscovery.parseStoredConfig(arena.allocator(), bytes)).?;
     };

--- a/src/autodiscovery_test.zig
+++ b/src/autodiscovery_test.zig
@@ -36,3 +36,18 @@ test "register response requires success status" {
         \\{"status":"error","data":{"uuid":"u1","token":"tok1"}}
     ));
 }
+
+test "stored auto discovery config owns duplicated strings" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const owned = blk: {
+        const bytes = try std.testing.allocator.dupe(u8,
+            \{"uuid":"u2","token":"tok2"}
+        );
+        defer std.testing.allocator.free(bytes);
+        break :blk (try autodiscovery.parseStoredConfig(arena.allocator(), bytes)).?;
+    };
+    try std.testing.expectEqualStrings("u2", owned.uuid);
+    try std.testing.expectEqualStrings("tok2", owned.token);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -126,7 +126,8 @@ pub fn main(init: std.process.Init.Minimal) !void {
     printMonitoringLists(allocator, cfg) catch {};
 
     if (shutdown_requested.load(.acquire)) return;
-    const startup_outcome = try runForegroundBasicInfoUpload(allocator, cfg, false, .startup);
+    var startup_outcome = try runForegroundBasicInfoUpload(allocator, cfg, false, .startup);
+    startup_outcome = try refreshAutoDiscoveryAfterUnauthorized(config_allocator, &cfg, allocator, startup_outcome);
     if (shutdown_requested.load(.acquire)) return;
     startBasicInfoLoop(allocator, cfg, basic_info_flow.shouldStartBackgroundLoopImmediately(startup_outcome));
 
@@ -140,6 +141,24 @@ pub fn main(init: std.process.Init.Minimal) !void {
         _ = try runForegroundBasicInfoUpload(allocator, cfg, false, .websocket_reconnect);
     }
     try stdout.writeAll("shutting down gracefully...\n");
+}
+
+
+fn refreshAutoDiscoveryAfterUnauthorized(
+    config_allocator: std.mem.Allocator,
+    cfg: *config.Config,
+    allocator: std.mem.Allocator,
+    outcome: basic_info_flow.ForegroundUploadOutcome,
+) !basic_info_flow.ForegroundUploadOutcome {
+    const err = switch (outcome) {
+        .failure => |e| e,
+        else => return outcome,
+    };
+    if (err != error.HttpUnauthorized) return outcome;
+    if (cfg.auto_discovery_key.len == 0) return outcome;
+    debug.log("basic info unauthorized with auto-discovery; invalidating cached token", .{});
+    try autodiscovery.invalidateAndRegister(config_allocator, cfg);
+    return try runForegroundBasicInfoUpload(allocator, cfg.*, false, .startup);
 }
 
 fn runPingDiagnostic(allocator: std.mem.Allocator, args: []const []const u8) !bool {

--- a/src/protocol/autodiscovery.zig
+++ b/src/protocol/autodiscovery.zig
@@ -4,6 +4,7 @@ const types = @import("types.zig");
 const config = @import("../config.zig");
 const http = @import("http.zig");
 const compat = @import("compat");
+const debug = @import("debug");
 
 /// Auto-discovery registration and cached token handling.
 pub const AutoDiscoveryConfig = struct {
@@ -29,6 +30,23 @@ pub fn load(allocator: std.mem.Allocator) !?AutoDiscoveryConfig {
     return parseStoredConfig(allocator, bytes);
 }
 
+pub fn clearCache(allocator: std.mem.Allocator) !void {
+    const path = try configPath(allocator);
+    defer allocator.free(path);
+    compat.deleteFileAbsolute(path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+}
+
+/// Drop the cached token and register again with the auto-discovery key.
+pub fn invalidateAndRegister(allocator: std.mem.Allocator, cfg: *config.Config) !void {
+    if (cfg.auto_discovery_key.len == 0) return;
+    try clearCache(allocator);
+    debug.log("auto-discovery: cached token rejected, re-registering", .{});
+    try register(allocator, cfg);
+}
+
 pub fn save(allocator: std.mem.Allocator, value: AutoDiscoveryConfig) !void {
     const path = try configPath(allocator);
     defer allocator.free(path);
@@ -43,16 +61,23 @@ pub fn save(allocator: std.mem.Allocator, value: AutoDiscoveryConfig) !void {
 pub fn applyExistingToken(allocator: std.mem.Allocator, cfg: *config.Config) !void {
     if (cfg.auto_discovery_key.len == 0) return;
     if (load(allocator) catch null) |stored| {
+        debug.log("auto-discovery: using cached token uuid={s}", .{stored.uuid});
         cfg.token = stored.token;
         return;
     }
+    debug.log("auto-discovery: cache miss, registering", .{});
     try register(allocator, cfg);
+    debug.log("auto-discovery: registered successfully", .{});
 }
 
 pub fn parseStoredConfig(allocator: std.mem.Allocator, bytes: []const u8) !?AutoDiscoveryConfig {
-    const parsed = std.json.parseFromSliceLeaky(AutoDiscoveryConfig, allocator, bytes, .{ .ignore_unknown_fields = true }) catch return null;
-    if (parsed.token.len == 0) return null;
-    return parsed;
+    var parsed = std.json.parseFromSlice(AutoDiscoveryConfig, allocator, bytes, .{ .ignore_unknown_fields = true }) catch return null;
+    defer parsed.deinit();
+    if (parsed.value.token.len == 0) return null;
+    return .{
+        .uuid = try allocator.dupe(u8, parsed.value.uuid),
+        .token = try allocator.dupe(u8, parsed.value.token),
+    };
 }
 
 pub fn allocRegisterRequest(allocator: std.mem.Allocator, key: []const u8) ![]const u8 {

--- a/src/protocol/http.zig
+++ b/src/protocol/http.zig
@@ -486,7 +486,7 @@ fn requestReadWithFamilyHeaders(
             redirects += 1;
             continue;
         }
-        debug.log("http request failed status={d} url={s}", .{ response.status, current_url });
+        debug.log("http request failed status={d}", .{response.status});
         const failed_status = response.status;
         response.deinit(allocator);
         if (failed_status == 401 or failed_status == 403) return error.HttpUnauthorized;
@@ -555,7 +555,7 @@ fn requestReadWithFamilyHeadersOnce(
         };
         errdefer allocator.free(response.body);
         if (response.status == 200 or isRedirectStatus(response.status)) return response;
-        debug.log("http attempt failed status={d} url={s}", .{ response.status, url });
+        debug.log("http attempt failed status={d}", .{response.status});
         const failed_status = response.status;
         response.deinit(allocator);
         if (attempt < max_retries) {

--- a/src/protocol/http.zig
+++ b/src/protocol/http.zig
@@ -4,6 +4,7 @@ const idna = @import("idna");
 const raw_conn = @import("raw_conn.zig");
 const net = @import("net");
 const compat = @import("compat");
+const debug = @import("debug");
 
 /// HTTP and proxy helpers shared by agent protocol clients.
 pub const max_response_body_bytes: usize = 64 * 1024 * 1024;
@@ -235,6 +236,19 @@ pub fn getToFileSha256Cfg(allocator: std.mem.Allocator, url: []const u8, cfg: an
 pub fn trimEndpoint(endpoint: []const u8) []const u8 {
     return std.mem.trimEnd(u8, endpoint, "/");
 }
+
+/// Format an HTTP Host header value (hostname or [ipv6], plus non-default port).
+pub fn formatHostHeader(allocator: std.mem.Allocator, host: []const u8, port: u16, use_tls: bool) ![]const u8 {
+    const default_port: u16 = if (use_tls) 443 else 80;
+    const is_ipv6 = std.mem.indexOfScalar(u8, host, ':') != null;
+    if (port == default_port) {
+        if (is_ipv6) return std.fmt.allocPrint(allocator, "[{s}]", .{host});
+        return allocator.dupe(u8, host);
+    }
+    if (is_ipv6) return std.fmt.allocPrint(allocator, "[{s}]:{d}", .{ host, port });
+    return std.fmt.allocPrint(allocator, "{s}:{d}", .{ host, port });
+}
+
 
 pub fn basicInfoUrl(allocator: std.mem.Allocator, endpoint: []const u8, token: []const u8) ![]const u8 {
     const raw = try std.fmt.allocPrint(allocator, "{s}/api/clients/uploadBasicInfo?token={s}", .{ trimEndpoint(endpoint), token });
@@ -472,7 +486,10 @@ fn requestReadWithFamilyHeaders(
             redirects += 1;
             continue;
         }
+        debug.log("http request failed status={d} url={s}", .{ response.status, current_url });
+        const failed_status = response.status;
         response.deinit(allocator);
+        if (failed_status == 401 or failed_status == 403) return error.HttpUnauthorized;
         return error.HttpStatusNotOk;
     }
 }
@@ -512,7 +529,9 @@ fn requestReadWithFamilyHeadersOnce(
         var req = std.Io.Writer.Allocating.init(allocator);
         defer req.deinit();
         const request_target = if (raw.proxied_plain) url else path;
-        try req.writer.print("{s} {s} HTTP/1.1\r\nHost: {s}\r\nUser-Agent: {s}\r\nConnection: close\r\n", .{ method, request_target, host, user_agent });
+        const host_header = try formatHostHeader(allocator, host, port, use_tls);
+        defer allocator.free(host_header);
+        try req.writer.print("{s} {s} HTTP/1.1\r\nHost: {s}\r\nUser-Agent: {s}\r\nConnection: close\r\n", .{ method, request_target, host_header, user_agent });
         if (raw.proxy_authorization) |authorization_value| try req.writer.print("Proxy-Authorization: {s}\r\n", .{authorization_value});
         if (payload.len != 0) {
             try req.writer.print("Content-Type: {s}\r\nContent-Length: {d}\r\n", .{ content_type, payload.len });
@@ -536,11 +555,14 @@ fn requestReadWithFamilyHeadersOnce(
         };
         errdefer allocator.free(response.body);
         if (response.status == 200 or isRedirectStatus(response.status)) return response;
+        debug.log("http attempt failed status={d} url={s}", .{ response.status, url });
+        const failed_status = response.status;
         response.deinit(allocator);
         if (attempt < max_retries) {
             compat.sleep(2 * std.time.ns_per_s);
             continue;
         }
+        if (failed_status == 401 or failed_status == 403) return error.HttpUnauthorized;
         return error.HttpStatusNotOk;
     }
 }
@@ -593,7 +615,9 @@ fn requestToFileSha256Once(allocator: std.mem.Allocator, url: []const u8, cfg: a
         var req = std.Io.Writer.Allocating.init(allocator);
         defer req.deinit();
         const request_target = if (raw.proxied_plain) url else path;
-        try req.writer.print("GET {s} HTTP/1.1\r\nHost: {s}\r\nUser-Agent: komari-zig-agent\r\nConnection: close\r\n", .{ request_target, host });
+        const host_header = try formatHostHeader(allocator, host, port, use_tls);
+        defer allocator.free(host_header);
+        try req.writer.print("GET {s} HTTP/1.1\r\nHost: {s}\r\nUser-Agent: komari-zig-agent\r\nConnection: close\r\n", .{ request_target, host_header });
         if (raw.proxy_authorization) |authorization_value| try req.writer.print("Proxy-Authorization: {s}\r\n", .{authorization_value});
         try req.writer.writeAll("\r\n");
         const request = try req.toOwnedSlice();

--- a/src/protocol/ws_client.zig
+++ b/src/protocol/ws_client.zig
@@ -195,9 +195,11 @@ fn connectRaw(allocator: std.mem.Allocator, url: []const u8, cfg: anytype) !*Cli
     var req = std.Io.Writer.Allocating.init(allocator);
     defer req.deinit();
     const request_target = if (raw_http.proxied_plain) url else target.path;
+    const host_header = try http.formatHostHeader(allocator, target.host, target.port, target.tls);
+    defer allocator.free(host_header);
     try req.writer.print(
         "GET {s} HTTP/1.1\r\nHost: {s}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: {s}\r\nSec-WebSocket-Version: 13\r\nUser-Agent: komari-zig-agent\r\n",
-        .{ request_target, target.host, nonce },
+        .{ request_target, host_header, nonce },
     );
     if (raw_http.proxy_authorization) |authorization| try req.writer.print("Proxy-Authorization: {s}\r\n", .{authorization});
     var cf: [2]std.http.Header = undefined;

--- a/test/http_test.zig
+++ b/test/http_test.zig
@@ -274,3 +274,36 @@ test "proxy environment wildcard bypasses all proxy use" {
         .no_proxy_lower = "*",
     }));
 }
+
+test "formatHostHeader includes non-default port and brackets ipv6" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    try std.testing.expectEqualStrings("panel.example", try http.formatHostHeader(allocator, "panel.example", 443, true));
+    try std.testing.expectEqualStrings("panel.example", try http.formatHostHeader(allocator, "panel.example", 80, false));
+    try std.testing.expectEqualStrings("panel.example:25774", try http.formatHostHeader(allocator, "panel.example", 25774, false));
+    try std.testing.expectEqualStrings("panel.example:8443", try http.formatHostHeader(allocator, "panel.example", 8443, true));
+    try std.testing.expectEqualStrings("[2001:db8::1]", try http.formatHostHeader(allocator, "2001:db8::1", 443, true));
+    try std.testing.expectEqualStrings("[2001:db8::1]:25774", try http.formatHostHeader(allocator, "2001:db8::1", 25774, false));
+}
+
+test "http client sends Host with non-default port" {
+    const responses = [_][]const u8{
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+    };
+    var server = try local_http.Server.start(std.testing.allocator, &responses);
+    const url = try server.url(std.testing.allocator, "/ping");
+    defer std.testing.allocator.free(url);
+    const body = try http.getReadCfg(std.testing.allocator, url, config.Config{});
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("ok", body);
+
+    var finished = try server.finish();
+    defer finished.deinit();
+    try std.testing.expectEqual(@as(usize, 1), finished.requests.len);
+    const host = finished.requests[0].header("Host") orelse return error.TestUnexpectedResult;
+    // Ephemeral listen port is never 80, so Host must include :port (matches Go net/http).
+    try std.testing.expect(std.mem.startsWith(u8, host, "127.0.0.1:"));
+    try std.testing.expect(!std.mem.eql(u8, host, "127.0.0.1"));
+}


### PR DESCRIPTION
## Summary
- HTTP/WebSocket `Host` header now includes the non-default port (e.g. `:25774`), matching Go `net/http` / RFC 7230.
- Auto-discovery cache load owns duplicated `uuid`/`token` strings (no leaky pointers into a freed buffer).
- On startup basic-info `401`/`403` while `--auto-discovery` is set: invalidate `auto-discovery.json`, re-register once, then retry upload.
- Debug logs for cache hit / register / HTTP status; regression tests for Host formatting and ownership.

Related to #30

## Test plan
- [ ] CI green on final head
- [ ] Reporter on Debian 13 with `http://host:25774 --auto-discovery` retests after upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 自动发现服务返回未授权时，系统会自动刷新凭据并重试启动信息上传，减少因凭据失效导致的失败。
  - HTTP 请求现在能正确处理 IPv6 地址及非默认端口，提升连接兼容性。
  - WebSocket 连接同步使用规范化的主机信息。

- **修复**
  - 修复已保存的自动发现配置在原始数据释放后可能无法正常使用的问题。
  - 401 和 403 响应现可被准确识别为未授权错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->