### PR TITLE
reconnect: rotate addrs on HTTP/WS app-layer failure; clear sticky v1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -328,6 +328,7 @@ fn addTest(
     addCompatImports(protocol_ws_client, compat_module, net_module);
     protocol_ws_client.addImport("debug", debug_module);
     protocol_ws_client.addImport("idna", idna_module);
+    protocol_ws_client.addImport("dns", dns_module);
     tests.root_module.addImport("protocol_ws_client", protocol_ws_client);
     tests.root_module.addImport("protocol_report_timing", b.createModule(.{
         .root_source_file = b.path("src/protocol/report_timing.zig"),

--- a/report_ws_v2_test.zig
+++ b/report_ws_v2_test.zig
@@ -163,3 +163,19 @@ fn expectArrayValue(object: std.json.ObjectMap, key: []const u8) !std.json.Array
     if (value != .array) return error.TestUnexpectedResult;
     return value.array;
 }
+
+
+test "sticky v1 is set only after successful v1 fallback connect" {
+    report_ws.initRequestedProtocolVersionForTest(2);
+    report_ws.resetConnectionProtocolVersionForTest();
+    defer report_ws.resetConnectionProtocolVersionForTest();
+
+    report_ws.applyV1FallbackConnectResultForTest(false);
+    try std.testing.expectEqual(@as(i32, 2), report_ws.uploadProtocolVersionForTest());
+
+    report_ws.applyV1FallbackConnectResultForTest(true);
+    try std.testing.expectEqual(@as(i32, 1), report_ws.uploadProtocolVersionForTest());
+
+    report_ws.prepareReconnectCycleForTest();
+    try std.testing.expectEqual(@as(i32, 2), report_ws.uploadProtocolVersionForTest());
+}

--- a/src/protocol/http.zig
+++ b/src/protocol/http.zig
@@ -637,7 +637,7 @@ fn requestReadAttemptWithAddressFailover(
     const proxy_url = try proxyFromProcess(allocator, scheme, host, port);
     defer if (proxy_url) |value| allocator.free(value);
     if (proxy_url != null) {
-        return requestReadViaRawConnection(
+        const response = try requestReadViaRawConnection(
             allocator,
             try connectRawHttp(allocator, scheme, host, port, use_tls, cfg.ignore_unsafe_cert, cfg.custom_dns, family, timeout_ms),
             method,
@@ -652,6 +652,18 @@ fn requestReadAttemptWithAddressFailover(
             user_agent,
             headers,
         );
+        switch (httpStatusAddressDecision(response.status)) {
+            .accept => return response,
+            .unauthorized => {
+                response.deinit(allocator);
+                return error.HttpUnauthorized;
+            },
+            .try_next => {
+                debug.log("http attempt failed status={d}", .{response.status});
+                response.deinit(allocator);
+                return error.HttpStatusNotOk;
+            },
+        }
     }
 
     const addrs = try dns.resolveHost(allocator, host, port, cfg.custom_dns);

--- a/src/protocol/http.zig
+++ b/src/protocol/http.zig
@@ -5,6 +5,7 @@ const raw_conn = @import("raw_conn.zig");
 const net = @import("net");
 const compat = @import("compat");
 const debug = @import("debug");
+const dns = @import("dns");
 
 /// HTTP and proxy helpers shared by agent protocol clients.
 pub const max_response_body_bytes: usize = 64 * 1024 * 1024;
@@ -157,6 +158,71 @@ pub fn writeResponseToFileSha256ForTest(allocator: std.mem.Allocator, response: 
 
 pub fn resolveRedirectUrlForTest(allocator: std.mem.Allocator, base_url: []const u8, location: []const u8) ![]const u8 {
     return resolveRedirectUrl(allocator, base_url, location);
+}
+
+pub const AddressStatusDecision = enum {
+    accept,
+    unauthorized,
+    try_next,
+};
+
+/// Decide whether an HTTP status should accept the address, fail auth, or rotate.
+pub fn httpStatusAddressDecision(status: u16) AddressStatusDecision {
+    if (status == 200 or isRedirectStatus(status)) return .accept;
+    if (status == 401 or status == 403) return .unauthorized;
+    return .try_next;
+}
+
+pub fn httpStatusAddressDecisionForTest(status: u16) AddressStatusDecision {
+    return httpStatusAddressDecision(status);
+}
+
+/// Expose process proxy lookup for websocket address failover.
+pub fn processProxyUrl(allocator: std.mem.Allocator, scheme: []const u8, host: []const u8, port: u16) !?[]const u8 {
+    return proxyFromProcess(allocator, scheme, host, port);
+}
+
+/// Test helper: try each address for a plain HTTP GET until 200.
+pub fn requestReadViaAddressesForTest(
+    allocator: std.mem.Allocator,
+    addrs: []const net.Address,
+    path: []const u8,
+    host: []const u8,
+    timeout_ms: u64,
+) ![]u8 {
+    const response = try requestReadOverAddresses(
+        allocator,
+        addrs,
+        .any,
+        "GET",
+        path,
+        "",
+        "",
+        "komari-zig-agent",
+        .{},
+        false,
+        host,
+        false,
+        timeout_ms,
+    );
+    errdefer response.deinit(allocator);
+    switch (httpStatusAddressDecision(response.status)) {
+        .accept => {
+            if (response.status != 200) {
+                response.deinit(allocator);
+                return error.HttpStatusNotOk;
+            }
+            return response.body;
+        },
+        .unauthorized => {
+            response.deinit(allocator);
+            return error.HttpUnauthorized;
+        },
+        .try_next => {
+            response.deinit(allocator);
+            return error.HttpStatusNotOk;
+        },
+    }
 }
 
 pub fn postJson(allocator: std.mem.Allocator, url: []const u8, payload: []const u8, cfg: anytype) !void {
@@ -517,54 +583,202 @@ fn requestReadWithFamilyHeadersOnce(
     const max_retries: u32 = if (cfg.max_retries < 0) 0 else @intCast(cfg.max_retries);
     var attempt: u32 = 0;
     while (true) : (attempt += 1) {
-        const raw = connectRawHttp(allocator, uri.scheme, host, port, use_tls, cfg.ignore_unsafe_cert, cfg.custom_dns, family, timeout_ms) catch |err| {
+        const response = requestReadAttemptWithAddressFailover(
+            allocator,
+            uri.scheme,
+            host,
+            port,
+            use_tls,
+            path,
+            url,
+            method,
+            payload,
+            content_type,
+            cfg,
+            family,
+            user_agent,
+            headers,
+            timeout_ms,
+        ) catch |err| {
+            if (err == error.HttpUnauthorized) return err;
             if (attempt < max_retries) {
                 compat.sleep(2 * std.time.ns_per_s);
                 continue;
             }
             return err;
         };
-        var conn = raw.conn;
-        defer raw.close(allocator);
-        var req = std.Io.Writer.Allocating.init(allocator);
-        defer req.deinit();
-        const request_target = if (raw.proxied_plain) url else path;
-        const host_header = try formatHostHeader(allocator, host, port, use_tls);
-        defer allocator.free(host_header);
-        try req.writer.print("{s} {s} HTTP/1.1\r\nHost: {s}\r\nUser-Agent: {s}\r\nConnection: close\r\n", .{ method, request_target, host_header, user_agent });
-        if (raw.proxy_authorization) |authorization_value| try req.writer.print("Proxy-Authorization: {s}\r\n", .{authorization_value});
-        if (payload.len != 0) {
-            try req.writer.print("Content-Type: {s}\r\nContent-Length: {d}\r\n", .{ content_type, payload.len });
-        }
-        var cf: [2]std.http.Header = undefined;
-        for (cloudflareHeaders(cfg, &cf)) |header| try req.writer.print("{s}: {s}\r\n", .{ header.name, header.value });
-        if (headers.authorization) |authorization| try req.writer.print("Authorization: {s}\r\n", .{authorization});
-        if (headers.content_encoding) |content_encoding| try req.writer.print("Content-Encoding: {s}\r\n", .{content_encoding});
-        try req.writer.writeAll("\r\n");
-        if (payload.len != 0) try req.writer.writeAll(payload);
-        const request = try req.toOwnedSlice();
-        defer allocator.free(request);
-        try conn.writer().writeAll(request);
-        try conn.flush();
-        const response = readHttpResponse(allocator, conn.reader()) catch |err| {
-            if (attempt < max_retries) {
-                compat.sleep(2 * std.time.ns_per_s);
-                continue;
-            }
-            return err;
-        };
-        errdefer allocator.free(response.body);
-        if (response.status == 200 or isRedirectStatus(response.status)) return response;
-        debug.log("http attempt failed status={d}", .{response.status});
-        const failed_status = response.status;
-        response.deinit(allocator);
-        if (attempt < max_retries) {
-            compat.sleep(2 * std.time.ns_per_s);
-            continue;
-        }
-        if (failed_status == 401 or failed_status == 403) return error.HttpUnauthorized;
-        return error.HttpStatusNotOk;
+        return response;
     }
+}
+
+fn requestReadAttemptWithAddressFailover(
+    allocator: std.mem.Allocator,
+    scheme: []const u8,
+    host: []const u8,
+    port: u16,
+    use_tls: bool,
+    path: []const u8,
+    full_url: []const u8,
+    method: []const u8,
+    payload: []const u8,
+    content_type: []const u8,
+    cfg: anytype,
+    family: raw_conn.AddressFamily,
+    user_agent: []const u8,
+    headers: Headers,
+    timeout_ms: u64,
+) !HttpResponse {
+    const proxy_url = try proxyFromProcess(allocator, scheme, host, port);
+    defer if (proxy_url) |value| allocator.free(value);
+    if (proxy_url != null) {
+        return requestReadViaRawConnection(
+            allocator,
+            try connectRawHttp(allocator, scheme, host, port, use_tls, cfg.ignore_unsafe_cert, cfg.custom_dns, family, timeout_ms),
+            method,
+            path,
+            full_url,
+            host,
+            port,
+            use_tls,
+            payload,
+            content_type,
+            cfg,
+            user_agent,
+            headers,
+        );
+    }
+
+    const addrs = try dns.resolveHost(allocator, host, port, cfg.custom_dns);
+    defer allocator.free(addrs);
+    return requestReadOverAddresses(
+        allocator,
+        addrs,
+        family,
+        method,
+        path,
+        payload,
+        content_type,
+        user_agent,
+        headers,
+        use_tls,
+        host,
+        cfg.ignore_unsafe_cert,
+        timeout_ms,
+    );
+}
+
+fn requestReadOverAddresses(
+    allocator: std.mem.Allocator,
+    addrs: []const net.Address,
+    family: raw_conn.AddressFamily,
+    method: []const u8,
+    path: []const u8,
+    payload: []const u8,
+    content_type: []const u8,
+    user_agent: []const u8,
+    headers: Headers,
+    use_tls: bool,
+    host: []const u8,
+    ignore_unsafe_cert: bool,
+    timeout_ms: u64,
+) !HttpResponse {
+    var last_err: ?anyerror = null;
+    var saw_status_not_ok = false;
+    for (addrs) |addr| {
+        if (!raw_conn.familyMatches(addr, family)) continue;
+        var addr_buf: [96]u8 = undefined;
+        const addr_text = raw_conn.formatAddress(&addr_buf, addr);
+        const conn = raw_conn.RawConn.connectResolved(allocator, addr, host, use_tls, ignore_unsafe_cert, timeout_ms) catch |err| {
+            last_err = err;
+            debug.log("tcp connect failed via {s}: {s}", .{ addr_text, @errorName(err) });
+            continue;
+        };
+        const raw = RawConnection{ .conn = conn };
+        const response = requestReadViaRawConnection(
+            allocator,
+            raw,
+            method,
+            path,
+            path,
+            host,
+            net.getPort(addr),
+            use_tls,
+            payload,
+            content_type,
+            EmptyCfg{},
+            user_agent,
+            headers,
+        ) catch |err| {
+            last_err = err;
+            debug.log("http request failed via {s}: {s}", .{ addr_text, @errorName(err) });
+            continue;
+        };
+        switch (httpStatusAddressDecision(response.status)) {
+            .accept => return response,
+            .unauthorized => {
+                debug.log("http unauthorized via {s} status={d}", .{ addr_text, response.status });
+                response.deinit(allocator);
+                return error.HttpUnauthorized;
+            },
+            .try_next => {
+                saw_status_not_ok = true;
+                last_err = error.HttpStatusNotOk;
+                debug.log("http skipping address {s} due to status={d}", .{ addr_text, response.status });
+                response.deinit(allocator);
+                continue;
+            },
+        }
+    }
+    if (saw_status_not_ok) return error.HttpStatusNotOk;
+    return last_err orelse error.ConnectFailed;
+}
+
+const EmptyCfg = struct {
+    ignore_unsafe_cert: bool = false,
+    custom_dns: []const u8 = "",
+    max_retries: i32 = 0,
+    cf_access_client_id: []const u8 = "",
+    cf_access_client_secret: []const u8 = "",
+};
+
+fn requestReadViaRawConnection(
+    allocator: std.mem.Allocator,
+    raw: RawConnection,
+    method: []const u8,
+    path: []const u8,
+    full_url: []const u8,
+    host: []const u8,
+    port: u16,
+    use_tls: bool,
+    payload: []const u8,
+    content_type: []const u8,
+    cfg: anytype,
+    user_agent: []const u8,
+    headers: Headers,
+) !HttpResponse {
+    var conn = raw.conn;
+    defer raw.close(allocator);
+    var req = std.Io.Writer.Allocating.init(allocator);
+    defer req.deinit();
+    const request_target = if (raw.proxied_plain) full_url else path;
+    const host_header = try formatHostHeader(allocator, host, port, use_tls);
+    defer allocator.free(host_header);
+    try req.writer.print("{s} {s} HTTP/1.1\r\nHost: {s}\r\nUser-Agent: {s}\r\nConnection: close\r\n", .{ method, request_target, host_header, user_agent });
+    if (raw.proxy_authorization) |authorization_value| try req.writer.print("Proxy-Authorization: {s}\r\n", .{authorization_value});
+    if (payload.len != 0) {
+        try req.writer.print("Content-Type: {s}\r\nContent-Length: {d}\r\n", .{ content_type, payload.len });
+    }
+    var cf: [2]std.http.Header = undefined;
+    for (cloudflareHeaders(cfg, &cf)) |header| try req.writer.print("{s}: {s}\r\n", .{ header.name, header.value });
+    if (headers.authorization) |authorization| try req.writer.print("Authorization: {s}\r\n", .{authorization});
+    if (headers.content_encoding) |content_encoding| try req.writer.print("Content-Encoding: {s}\r\n", .{content_encoding});
+    try req.writer.writeAll("\r\n");
+    if (payload.len != 0) try req.writer.writeAll(payload);
+    const request = try req.toOwnedSlice();
+    defer allocator.free(request);
+    try conn.writer().writeAll(request);
+    try conn.flush();
+    return try readHttpResponse(allocator, conn.reader());
 }
 
 fn requestToFileSha256(allocator: std.mem.Allocator, url: []const u8, cfg: anytype, file: std.Io.File) ![32]u8 {

--- a/src/protocol/http.zig
+++ b/src/protocol/http.zig
@@ -202,7 +202,13 @@ pub fn requestReadViaAddressesForTest(
         .{},
         false,
         host,
-        false,
+        struct {
+            ignore_unsafe_cert: bool = false,
+            custom_dns: []const u8 = "",
+            max_retries: i32 = 0,
+            cf_access_client_id: []const u8 = "",
+            cf_access_client_secret: []const u8 = "",
+        }{},
         timeout_ms,
     );
     errdefer response.deinit(allocator);
@@ -662,7 +668,7 @@ fn requestReadAttemptWithAddressFailover(
         headers,
         use_tls,
         host,
-        cfg.ignore_unsafe_cert,
+        cfg,
         timeout_ms,
     );
 }
@@ -679,7 +685,7 @@ fn requestReadOverAddresses(
     headers: Headers,
     use_tls: bool,
     host: []const u8,
-    ignore_unsafe_cert: bool,
+    cfg: anytype,
     timeout_ms: u64,
 ) !HttpResponse {
     var last_err: ?anyerror = null;
@@ -688,7 +694,7 @@ fn requestReadOverAddresses(
         if (!raw_conn.familyMatches(addr, family)) continue;
         var addr_buf: [96]u8 = undefined;
         const addr_text = raw_conn.formatAddress(&addr_buf, addr);
-        const conn = raw_conn.RawConn.connectResolved(allocator, addr, host, use_tls, ignore_unsafe_cert, timeout_ms) catch |err| {
+        const conn = raw_conn.RawConn.connectResolved(allocator, addr, host, use_tls, cfg.ignore_unsafe_cert, timeout_ms) catch |err| {
             last_err = err;
             debug.log("tcp connect failed via {s}: {s}", .{ addr_text, @errorName(err) });
             continue;
@@ -705,7 +711,7 @@ fn requestReadOverAddresses(
             use_tls,
             payload,
             content_type,
-            EmptyCfg{},
+            cfg,
             user_agent,
             headers,
         ) catch |err| {
@@ -732,14 +738,6 @@ fn requestReadOverAddresses(
     if (saw_status_not_ok) return error.HttpStatusNotOk;
     return last_err orelse error.ConnectFailed;
 }
-
-const EmptyCfg = struct {
-    ignore_unsafe_cert: bool = false,
-    custom_dns: []const u8 = "",
-    max_retries: i32 = 0,
-    cf_access_client_id: []const u8 = "",
-    cf_access_client_secret: []const u8 = "",
-};
 
 fn requestReadViaRawConnection(
     allocator: std.mem.Allocator,

--- a/src/protocol/raw_conn.zig
+++ b/src/protocol/raw_conn.zig
@@ -186,7 +186,16 @@ pub fn rescanCaBundleForTest() !void {
     defer bundle.deinit(std.heap.page_allocator);
 }
 
-fn familyMatches(addr: net.Address, family: AddressFamily) bool {
+pub fn resolveAddresses(
+    allocator: std.mem.Allocator,
+    host: []const u8,
+    port: u16,
+    custom_dns: []const u8,
+) ![]net.Address {
+    return dns.resolveHost(allocator, host, port, custom_dns);
+}
+
+pub fn familyMatches(addr: net.Address, family: AddressFamily) bool {
     return switch (family) {
         .any => true,
         .ipv4 => net.isIpv4(addr),
@@ -199,7 +208,7 @@ fn connectStreamAddress(addr: net.Address, timeout_ms: u64) !net.Stream {
     return net.connectWithTimeout(addr, timeout_ms);
 }
 
-fn formatAddress(buf: *[96]u8, addr: net.Address) []const u8 {
+pub fn formatAddress(buf: *[96]u8, addr: net.Address) []const u8 {
     var writer: std.Io.Writer = .fixed(buf);
     addr.format(&writer) catch return "<invalid-address>";
     return writer.buffered();

--- a/src/protocol/report_ws.zig
+++ b/src/protocol/report_ws.zig
@@ -87,14 +87,18 @@ pub fn uploadProtocolVersionForTest() i32 {
     return v2_state.uploadProtocolVersion();
 }
 
-/// Mirrors connectReportWs sticky-v1 rules without network I/O.
-pub fn applyV1FallbackConnectResultForTest(connect_ok: bool) void {
+fn applyV1FallbackConnectResult(connect_ok: bool) void {
     if (connect_ok) {
         v2_state.setConnectionProtocolVersion(1);
         v2_state.resetV2ProtocolFailures(1);
     } else {
         v2_state.resetConnectionProtocolVersion();
     }
+}
+
+/// Test wrapper around sticky-v1 rules without network I/O.
+pub fn applyV1FallbackConnectResultForTest(connect_ok: bool) void {
+    applyV1FallbackConnectResult(connect_ok);
 }
 
 pub fn prepareReconnectCycleForTest() void {
@@ -234,11 +238,10 @@ fn connectReportWs(allocator: std.mem.Allocator, cfg: config.Config) !*ws_client
             defer allocator.free(fallback_url);
             const fallback_ws = ws_client.connect(allocator, fallback_url, cfg) catch |fallback_err| {
                 // Failed v1 fallback must not stick; next reconnect cycle prefers requested v2 again.
-                v2_state.resetConnectionProtocolVersion();
+                applyV1FallbackConnectResult(false);
                 return fallback_err;
             };
-            v2_state.setConnectionProtocolVersion(1);
-            v2_state.resetV2ProtocolFailures(1);
+            applyV1FallbackConnectResult(true);
             return fallback_ws;
         }
         return err;

--- a/src/protocol/report_ws.zig
+++ b/src/protocol/report_ws.zig
@@ -83,6 +83,24 @@ pub fn resetConnectionProtocolVersionForTest() void {
     v2_state.resetConnectionProtocolVersion();
 }
 
+pub fn uploadProtocolVersionForTest() i32 {
+    return v2_state.uploadProtocolVersion();
+}
+
+/// Mirrors connectReportWs sticky-v1 rules without network I/O.
+pub fn applyV1FallbackConnectResultForTest(connect_ok: bool) void {
+    if (connect_ok) {
+        v2_state.setConnectionProtocolVersion(1);
+        v2_state.resetV2ProtocolFailures(1);
+    } else {
+        v2_state.resetConnectionProtocolVersion();
+    }
+}
+
+pub fn prepareReconnectCycleForTest() void {
+    v2_state.resetConnectionProtocolVersion();
+}
+
 fn writeReportOnce(allocator: std.mem.Allocator, ws: *ws_client.Client, cfg: config.Config) !void {
     const snap = try provider.snapshotWithOptions(snapshotOptions(cfg));
     var owns_gpu_json = true;
@@ -212,10 +230,13 @@ fn connectReportWs(allocator: std.mem.Allocator, cfg: config.Config) !*ws_client
     const ws = ws_client.connect(allocator, url, cfg) catch |err| {
         const attempt = v2_state.noteV2AttemptResult(protocol_version, err);
         if (attempt.fallback) {
-            v2_state.setConnectionProtocolVersion(1);
             const fallback_url = try http.reportWsUrlForProtocol(allocator, cfg.endpoint, cfg.token, 1);
             defer allocator.free(fallback_url);
-            const fallback_ws = try ws_client.connect(allocator, fallback_url, cfg);
+            const fallback_ws = ws_client.connect(allocator, fallback_url, cfg) catch |fallback_err| {
+                // Failed v1 fallback must not stick; next reconnect cycle prefers requested v2 again.
+                v2_state.resetConnectionProtocolVersion();
+                return fallback_err;
+            };
             v2_state.setConnectionProtocolVersion(1);
             v2_state.resetV2ProtocolFailures(1);
             return fallback_ws;
@@ -266,6 +287,8 @@ fn runPostFallback(allocator: std.mem.Allocator, cfg: config.Config, stop_reques
 }
 
 fn connectReportWsWithRetries(allocator: std.mem.Allocator, cfg: config.Config, stop_requested: ?*const std.atomic.Value(bool)) !*ws_client.Client {
+    // Prefer requested protocol on each reconnect cycle (clears sticky v1 after a dropped session).
+    v2_state.resetConnectionProtocolVersion();
     var retry: i32 = 0;
     while (retry <= cfg.max_retries) : (retry += 1) {
         if (isStopRequested(stop_requested)) return error.ShutdownRequested;

--- a/src/protocol/ws_client.zig
+++ b/src/protocol/ws_client.zig
@@ -183,8 +183,42 @@ pub fn connect(allocator: std.mem.Allocator, url: []const u8, cfg: anytype) !*Cl
 fn connectRaw(allocator: std.mem.Allocator, url: []const u8, cfg: anytype) !*Client {
     const target = try parseUrl(url);
     const scheme = if (target.tls) "wss" else "ws";
+    const family = http.dashboardAddressFamily(cfg);
+    const timeout_ms = http.timeoutMsForConfig(cfg);
     debug.log("websocket transport connect start host={s} port={d} tls={}", .{ target.host, target.port, target.tls });
-    const raw_http = try http.connectRawHttp(allocator, scheme, target.host, target.port, target.tls, cfg.ignore_unsafe_cert, cfg.custom_dns, http.dashboardAddressFamily(cfg), http.timeoutMsForConfig(cfg));
+
+    const proxy_url = try http.processProxyUrl(allocator, scheme, target.host, target.port);
+    defer if (proxy_url) |value| allocator.free(value);
+    if (proxy_url != null) {
+        const raw_http = try http.connectRawHttp(allocator, scheme, target.host, target.port, target.tls, cfg.ignore_unsafe_cert, cfg.custom_dns, family, timeout_ms);
+        return finishConnectHandshake(allocator, url, target, cfg, raw_http);
+    }
+
+    const addrs = try raw_conn.resolveAddresses(allocator, target.host, target.port, cfg.custom_dns);
+    defer allocator.free(addrs);
+    var last_err: ?anyerror = null;
+    for (addrs) |addr| {
+        if (!raw_conn.familyMatches(addr, family)) continue;
+        var addr_buf: [96]u8 = undefined;
+        const addr_text = raw_conn.formatAddress(&addr_buf, addr);
+        const conn = raw_conn.RawConn.connectResolved(allocator, addr, target.host, target.tls, cfg.ignore_unsafe_cert, timeout_ms) catch |err| {
+            last_err = err;
+            debug.log("websocket tcp/tls failed via {s}: {s}", .{ addr_text, @errorName(err) });
+            continue;
+        };
+        const raw_http = http.RawConnection{ .conn = conn };
+        const client = finishConnectHandshake(allocator, url, target, cfg, raw_http) catch |err| {
+            last_err = err;
+            debug.log("websocket skipping address {s} due to {s}", .{ addr_text, @errorName(err) });
+            continue;
+        };
+        debug.log("websocket connected via {s}", .{addr_text});
+        return client;
+    }
+    return last_err orelse error.ConnectFailed;
+}
+
+fn finishConnectHandshake(allocator: std.mem.Allocator, url: []const u8, target: Target, cfg: anytype, raw_http: http.RawConnection) !*Client {
     errdefer raw_http.close(allocator);
     const raw = raw_http.conn;
     debug.log("websocket transport connected host={s} port={d}", .{ target.host, target.port });
@@ -217,7 +251,6 @@ fn connectRaw(allocator: std.mem.Allocator, url: []const u8, cfg: anytype) !*Cli
     if (raw_http.proxy_authorization) |authorization| allocator.free(authorization);
     return client;
 }
-
 pub fn parseUrl(url: []const u8) !Target {
     const prefix = if (std.mem.startsWith(u8, url, "wss://")) "wss://" else if (std.mem.startsWith(u8, url, "ws://")) "ws://" else return error.InvalidWebSocketUrl;
     const tls = std.mem.eql(u8, prefix, "wss://");

--- a/test/http_test.zig
+++ b/test/http_test.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const config = @import("config");
 const http = @import("protocol_http");
+const net = @import("net");
 const local_http = @import("local_http.zig");
 
 test "endpoint helpers trim slash and place token query" {
@@ -306,4 +307,38 @@ test "http client sends Host with non-default port" {
     // Ephemeral listen port is never 80, so Host must include :port (matches Go net/http).
     try std.testing.expect(std.mem.startsWith(u8, host, "127.0.0.1:"));
     try std.testing.expect(!std.mem.eql(u8, host, "127.0.0.1"));
+}
+
+
+test "http status address decision accepts redirects and rejects unauthorized" {
+    try std.testing.expectEqual(http.AddressStatusDecision.accept, http.httpStatusAddressDecisionForTest(200));
+    try std.testing.expectEqual(http.AddressStatusDecision.accept, http.httpStatusAddressDecisionForTest(302));
+    try std.testing.expectEqual(http.AddressStatusDecision.unauthorized, http.httpStatusAddressDecisionForTest(401));
+    try std.testing.expectEqual(http.AddressStatusDecision.unauthorized, http.httpStatusAddressDecisionForTest(403));
+    try std.testing.expectEqual(http.AddressStatusDecision.try_next, http.httpStatusAddressDecisionForTest(404));
+    try std.testing.expectEqual(http.AddressStatusDecision.try_next, http.httpStatusAddressDecisionForTest(502));
+}
+
+test "http client rotates to next address after non-200 status" {
+    const bad_responses = [_][]const u8{
+        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    };
+    const good_responses = [_][]const u8{
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+    };
+    var bad = try local_http.Server.start(std.testing.allocator, &bad_responses);
+    defer bad.join() catch {};
+    var good = try local_http.Server.start(std.testing.allocator, &good_responses);
+    defer good.join() catch {};
+
+    const bad_port = bad.ctx.listener.socket.address.getPort();
+    const good_port = good.ctx.listener.socket.address.getPort();
+    const addrs = [_]net.Address{
+        try net.parseIp("127.0.0.1", bad_port),
+        try net.parseIp("127.0.0.1", good_port),
+    };
+
+    const body = try http.requestReadViaAddressesForTest(std.testing.allocator, &addrs, "/", "127.0.0.1", 5_000);
+    defer std.testing.allocator.free(body);
+    try std.testing.expectEqualStrings("ok", body);
 }

--- a/test/v2_state_test.zig
+++ b/test/v2_state_test.zig
@@ -57,3 +57,29 @@ test "successful v2 attempt resets failure count" {
     try std.testing.expectEqual(@as(u32, 1), next.failures);
     try std.testing.expect(!next.fallback);
 }
+
+
+test "sticky connection version clears back to requested v2" {
+    v2_state.initRequestedProtocolVersion(2);
+    v2_state.resetConnectionProtocolVersion();
+    try std.testing.expectEqual(@as(i32, 2), v2_state.uploadProtocolVersion());
+
+    v2_state.setConnectionProtocolVersion(1);
+    try std.testing.expectEqual(@as(i32, 1), v2_state.uploadProtocolVersion());
+
+    v2_state.resetConnectionProtocolVersion();
+    try std.testing.expectEqual(@as(i32, 2), v2_state.uploadProtocolVersion());
+}
+
+test "v2 protocol handshake failures count toward fallback" {
+    v2_state.initRequestedProtocolVersion(2);
+    v2_state.resetConnectionProtocolVersion();
+
+    try std.testing.expect(v2_state.isV2ProtocolFailure(error.HttpStatusNotOk));
+    try std.testing.expect(v2_state.isV2ProtocolFailure(error.WebSocketHandshakeFailed));
+    try std.testing.expect(!v2_state.isV2ProtocolFailure(error.ConnectFailed));
+
+    const first = v2_state.noteV2AttemptResult(2, error.WebSocketHandshakeFailed);
+    try std.testing.expectEqual(@as(u32, 1), first.failures);
+    try std.testing.expect(!first.fallback);
+}


### PR DESCRIPTION
## Summary
Related to #33

修复 CDN/ESA 多边缘场景下 Agent 卡在坏地址 + sticky v1 导致必须重启才能上线的问题。

### A) 应用层失败时轮换解析地址
- Dashboard HTTP / WS 非代理路径：每次 attempt 只 resolve 一次，对每个匹配 family 的地址完整走 connect → 请求/握手
- HTTP 非 200（除 401/403 立即 `HttpUnauthorized`）或 WS 非 101 / handshake 失败：关闭连接并尝试下一个地址
- 全部失败返回最后相关错误；外层 `max_retries` 仍会重新 resolve
- 代理路径保持原样

### B) sticky v1
- `connectReportWs`：只有 v1 fallback **连接成功** 后才 `setConnectionProtocolVersion(1)`
- v1 fallback 失败则 `resetConnectionProtocolVersion()`，下次仍优先请求的 v2
- `connectReportWsWithRetries` 开始时 reset，使每次 reconnect cycle 重新偏好 v2

### C) 回归测试
- sticky-v1 仅在成功 fallback 后置位；失败/新 reconnect cycle 回到 requested v2
- HTTP 双 loopback listener：首地址 404、次地址 200 时轮换成功
- `httpStatusAddressDecision` 单元覆盖

请等本 PR 的 CI 全绿后再合并；我不会自行 merge / tag / release。

## Test plan
- [ ] CI `Build` / tests green on final head
- [ ] 可选：复现 CDN 多 A/AAAA + 部分边缘非 200/非 101 时，无需重启即可轮换上线

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - HTTP 请求支持解析多个地址并按顺序尝试连接，在非授权错误时自动故障转移。
  - WebSocket 连接支持多地址连接尝试，并继续兼容代理连接。
  - v1 协议回退仅在连接成功后生效；失败或重新连接时恢复优先使用 v2。

- **Bug 修复**
  - 修复 v1 回退失败后协议版本状态未正确清理的问题。

- **测试**
  - 增加多地址 HTTP 请求、状态码处理及协议回退状态测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->